### PR TITLE
Add missing Partner pages

### DIFF
--- a/overview/partner_content_reqs.md
+++ b/overview/partner_content_reqs.md
@@ -5,4 +5,135 @@ layout: default
 section_title: Overview
 ---
 
-TODO
+## Submitting Information for a Marketplace Listing
+
+We want to help you succeed, so we created this guide to ensure we have all the necessary content to properly publish your App on the [Procore Marketplace](https://marketplace.procore.com/).
+We collect the information we need from the Marketplace Listing section of your App page on the Developer Portal, and additional material you provide to our App Validation Engineer.
+Please ensure the content you supply for your Marketplace tile - descriptions, screenshots, video, etc. - accurately reflects the App’s core experience.
+
+Once you have everything assembled you can log in to your Procore Developer Portal account and visit your App page to enter and submit information for your Marketplace listing.
+The following sections summarize the various fields found in the Marketplace Listing section of your App page.
+All field entries and selections are required unless otherwise noted.
+
+### App Tab
+
+**Name** - The public-facing name for your App.
+
+- Must not infringe on a trademark or copyright for any other products or services.
+- Must be unique and be different from any other App name on the Marketplace.
+- Must not include the word <em>Procore</em> anywhere in the name.
+- Must be a clear and intuitive name suitable for the Marketplace.
+- Must match the Developer App Name as defined on the Developer Portal.
+- Must not contain the name of the developer, ISV, or other entity that created the App.
+- Procore makes the final determination on whether your proposed App name is acceptable.
+
+**Description** - A detailed description of your App for display on the Marketplace. Similar to an ‘elevator pitch’.
+
+- Must not exceed 500 characters in length.
+
+**Tagline** - A brief, clear, and concise (short) description of your App. Used as search text for Marketplace searches.
+
+- Must not exceed 40 characters in length.
+
+**Category** - Corresponds to the main functionality of your App.
+
+- Choose the categories that apply to your App.
+
+_Note_: Procore retains the right to re-assign your app to a different category if, upon review, we deem that your category choice is incorrect.
+
+**Built By** - Name of the organization that developed your App. Normally, this is your company name.
+
+**About Your Company** - Lets the audience get to know your company by giving them insight into your company history, experience, and expertise.
+
+**How it Works** - Describes the functionality between Procore and your App and how it works from a technical point of view.
+
+- Must not exceed 500 characters in length.
+
+### Support Tab
+
+**Support Email** - Dedicated email address for support requests.
+
+**Support Website URL** - URL for the support website link for your App.
+
+**Support Website Label** - Text label that displays for your support website link.
+
+**Additional Requirements** - Support website must satisfy the following.
+
+- Detailed summary of what the core App does and how it integrates with Procore.
+- Privacy policy (in English) that details how the App will be using any third-party data.
+- Clear instructions on how to get started using the App.
+- Test account (for the internal Procore QA team only). Must be capable of  testing all functions of the integration.
+
+**Recommended** - More (optional) suggestions for providing the best possible support experience:
+
+- Display the version number of the App and the date it was last updated.
+- Host a dedicated, downloadable support article.
+- Produce and host instructional videos.
+- Allow Procore to curate and host your instructional material on our Support Site.
+
+### Features Tab
+
+**Feature (x)** - Must provide descriptions of at least three features of your App.
+Each description must not exceed 100 characters in length.
+
+### Links Tab
+
+**Link URL** (optional) - URL to external web content you want to include in your Marketplace listing.
+These can be links to user documentation, your company website, case studies, etc.
+
+**Link Label** (optional) - Text label that displays for your external web link.
+
+### Required Procore Tools Tab
+
+**Procore Tools** - These are the Procore tools that are required for your App to function properly.
+
+### Integration Requirments Tab
+
+**Requirement (optional)** - Short descriptions of any prerequisites that must be met in order for your App to function properly.
+For example, product subscriptions, proper licensing, third-party systems, etc.
+Also, list any specific permission settings in Procore that are required to administer or use your App.
+For each Procore tool your App integrates with, indicate whether Read Only, Standard, or Admin permissions are required.
+
+### Media Tab
+
+**Logo** - Standard logo for your App or company. Also serves as App icon.
+
+- Image dimensions must be 200 x 200 px with a transparent or white background.
+- Must be one of the following formats: .EPS, .SVG, .AI, or .PNG.
+- Must not resemble the Procore logo/icon (see Procore Branding Guidelines).
+- Artwork must not infringe on any trademarked or copyrighted work.
+
+**Screenshots** - A minimum of three screenshots must be provided.
+
+- Accepted File Formats: .PNG or .JPG, .JPEG Must follow a 16:9 resolution format. (Example resolution: 1920x1080px at 72dpi)
+- Must show the App in use, and not merely title art, login page, or splashscreens.
+
+**Demo Videos** (recommended) - For use on the Marketplace and Procore Support Site.
+
+- Accepted File Formats: .MP4 or .MOV, Minimum resolution: 720p, 24fps screen recording. Must include instructional voice over audio.
+- Video must show the App moving data in/out of Procore and describe what tools it connects with through the Procore API.
+- Please submit the actual video file or provide a download link to a file storage service for files larger than 10mb. Direct links to online videos will not be accepted.
+
+## Additional App Submission Material
+
+In addition to the required information you provide for your Marketplace Liksting through the Developer Portal there are a number of items that you submit directly to Procore for review during the App submission and publication process.
+Your Procore App Validation Engineer will provide you access to a shared drive where you can upload and store these additional materials including documents, video files, imagery, or other items requested by our App Validation Engineer.
+
+### Pricing Information
+
+- Indicate whether your App is a free or paid integration. [Apps can have a trial period, but the integration itself cannot have a trial period. It is either free or paid.]
+- If your App requires the purchase of software, or you charge for the integration itself, then clearly indicate this in your submission.
+
+### Marketing Video
+
+You may elect to provide an additional marketing video promoting your App and company. [same file format and technical requirements as demo videos described above.]
+
+- Accepted File Formats: .MP4 or .MOV, Minimum resolution: 720p, 24fps screen recording. Maximum time: 3 min
+
+### App Banner (Logo)
+
+In addition to the App logo/icon you upload on the Developer Portal, you can submit a second logo, or ‘banner’ image that is not constrained by the 200x200 limitation.
+
+## See Also
+
+[Sales and Support Requirements]({{ site.url }}{{ site.baseurl }}{% link overview/partner_support_content_reqs.md %})

--- a/overview/partner_support_content_reqs.md
+++ b/overview/partner_support_content_reqs.md
@@ -5,4 +5,56 @@ layout: default
 section_title: Overview
 ---
 
-TODO
+## Primary Sales Contact Information
+
+The following information is needed regarding the primary sales contact for your App.
+This information will not be displayed on the Marketplace directly.
+We will use this contact information for forwarding leads when they fill out the contact form on our site.
+
+* Name
+* Telephone Number
+* Email Address
+
+## Sales Team Training
+
+Your sales team must be knowledgeable about the Procore integration and capable of supporting customers who may contact them regarding its use or implementation.
+
+## Establish a Viable Support System
+
+Critical to the success of your App/integration is the availability of a viable and capable support system.
+You must provide a means for customers to easily contact your support team via email and/or telephone.
+The first line of support for troubleshooting issues with your App should be done by your support team.
+Customers should not be directed to Procore Support for help with your App.
+If your team finds a possible technical problem with your integration and Procore, they can escalate the issue to their Procore Partner Manager to coordinate a resolution to the problem.
+Procore Support is not equiped to troubleshoot technical issues with an integration.
+Please work with your Procore Partner Manager and our publisher team to debug technical issues with your integration.
+
+To provide an acceptable level of technical support for your App you must:
+
+* Establish and maintain an active support medium with up-to-date support content.
+* Agree to keep your App's support information and user documentation updated as changes occur.
+* Provide a publicly accessible URL for support documentation.
+* Publish clearly stated hours-of-operation for your support team.
+
+## Support Landing Page
+
+Provide a Support page on your corporate website that includes the following:
+
+* Clear instructions on ‘how to get started’ using your App/integration.
+* Detailed summary of what the core App does and how it interacts with Procore through the integration.
+* Privacy policy in English that details how your App will be using any third-party data.
+
+## Support Contact Information
+
+* Support email address (mandatory)
+* Support website (optional)
+* Support hours of operation
+
+## Support Documentation
+
+* Provide a URL to your support article or upload a .docx with the support content.
+* Describe what your application does.
+* Describe What your integration does. (in-depth, and how to activate it)
+* Provide the version number of the integration and last date it was updated.
+* Test account (for the internal Procore QA team only). Must be capable of testing all functions of the integration.
+* Demo video is optional, screenshots are necessary.

--- a/overview/partner_tech_reqs.md
+++ b/overview/partner_tech_reqs.md
@@ -5,4 +5,37 @@ layout: default
 section_title: Overview
 ---
 
-TODO
+## App Submittal and Technical Review
+
+The following conditions must be met in order to successfully complete the App Markletplace submittal and technical review process.
+
+* Provide details of any paid test accounts that are needed in order to test and use your service.
+* Provide details of any test accounts that might be needed for third-party services.
+* List all Procore tools/resources that your App makes API calls to, and which direction the information is flowing.
+(e.g., "App pulls data from Procore’s Daily Log tool and pushes into our ____ tool on an automated schedule.")
+* Your application must be registered and linked to a proper App ID and Application Name. Any applications that reference the live Procore API without reference to their App ID will be rejected.
+* Prior to publication, you must verify that your application is showing up in the Developer Portal, and that all calls to the Procore API endpoints are appearing as they are made.
+We will not allow an application to be published that we are unable to track.
+This is necessary so that we can monitor server usage and application security.
+* All applications may only use Procore’s publicly documented production APIs.
+* Applications that transmit viruses, files, computer code, or programs that harm or disrupt Procore user’s experience including Push Notifications will be rejected.
+* Your application must use the approved Oauth mechanism for authenticating users.
+Any use of embedded logins or passwords is strictly prohibited; your application must support the full token - refresh mechanism in order to be published.
+* Applications must not make excessive use of polling mechanisms, and should strive to use Procore’s event-based mechanisms for determining when and how to update data.
+* Integrations should not display ad banners or test advertisements within Procore.
+
+## Functional Test and User Experience Review
+
+The following conditions must be met in order to successfully complete the functional test and user experience review process.
+
+* Apps submitted to the Procore Marketplace must be final versions.
+The Marketplace is not a software testing service.
+Demos, betas, and trial versions do not belong on the Marketplace.
+* No placeholder text, empty websites, or any other temporary content are allowed in the App when you submit it.
+* Make sure you have turned on and initialized any necessary back-end services and set them to Production versions.
+* Your App must successfully complete thorough functional testing with no signs of issues/bugs.
+* Prior to submitting your App for publication, you must successfully test the entire end-user onboarding process.
+You must have detailed step-by-step instructions for setting up and activating the integration.
+* Confirm that data pushed to Procore from your App shows up correctly without requiring extra work for the user.
+* Once published to the Marketplace, your App must be capable of supporting a large number of users.
+* Your App must provide significant value to Procore customers and enhance their experience with the Procore platform.


### PR DESCRIPTION
These pages existed in the previous version of the repository but had not
been ported over due to the fact that they are not linked in the sidebar.

Closes #11 