### PR TITLE
✂️  Remove Country Code pages

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -95,8 +95,6 @@
       url: /date-time
     - title: Working with Time Zones
       url: /tutorial-timezones
-    - title: Using Country Codes
-      url: /country-codes
     - title: MPZ Request Headers
       url: /mpz-headers
     - title: Working with Documents


### PR DESCRIPTION
The message of this page is that, when a Procore API endpoint asks for a `country_code` or a `state_code` parameter, they should be supplied following the Alpha-2 of the ISO-3166 specification.

This page also lists all the endpoints that expect those parameters, and the reference of each one of those endpoints already specified the correct format, e.g.:

<img width="1197" alt="Snap 2021-06-28 at 11 46 28 AM" src="https://user-images.githubusercontent.com/74197530/123688094-7e948c80-d806-11eb-8e9e-dddaa1c3da88.png">

Therefore, there is no need for someone browsing the API reference to reach out for a separate guide page, since the information they need about the format of the string is already present in the reference page.