### PR TITLE
BIM-1081 BIM Webviewer label updates

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -169,8 +169,8 @@
 
 - title: Other Procore APIs
   items:
-    - title: VDC Web Viewer API
-      url: /vdc-web-viewer
+    - title: BIM Web Viewer API
+      url: /bim-web-viewer
 
 - title: Tools
   items:

--- a/other_procore_apis/bim_web_viewer.md
+++ b/other_procore_apis/bim_web_viewer.md
@@ -1,17 +1,17 @@
 ---
-permalink: /vdc-web-viewer
-title: "Procore VDC Web Viewer: Integrator Documentation"
+permalink: /bim-web-viewer
+title: "Procore BIM Web Viewer: Integrator Documentation"
 layout: default
 section_title: Other Procore APIs
 ---
 
 ## Getting started
 
-The Procore VDC Web Viewer is a single distributable Javascript file.
+The Procore BIM Web Viewer is a single distributable Javascript file.
 
 Instantiate the viewer with the options argument, and start rendering when ready.
 
-- Add `<script type='text/javascript' src='dist/Procore.Vdc.WebViewer.js'></script>` to your page
+- Add `<script type='text/javascript' src='dist/Procore.Bim.Webviewer.js'></script>` to your page
 - Instantiate a new viewer with options: `const viewer = new ProcoreBim.Webviewer(options);`
 - Start the viewer: `viewer.start();`
 
@@ -1300,7 +1300,7 @@ Promise(boolean)
 }
 ```
 
-The version of the WebViewer which is being used.
+The version of the Webviewer which is being used.
 
 `parentElement [Element` (required)
 
@@ -1405,7 +1405,7 @@ Provided by a Procore service.
   }
 }
 ```
-Initializes the WebViewer with the camera.
+Initializes the Webviewer with the camera.
 
 `swEnable [boolean]`
 


### PR DESCRIPTION
**Which issue #** https://procoretech.atlassian.net/browse/BIM-1081

## Background

`VDC` is no longer used and the broader acronym `BIM` (Building Information Models) is preferred and the Webviewer will henceforth be referred as such.

## Changes

* `navigation.yml` now points to `bim_web_viewer.md`
* `vdc_web_viewer.md` renamed to `bim_web_viewer.md`
* `bim_web_viewer.md` updated to name `VDC` references to `BIM`

``` 
    /
  +-- _data
M ¦   +-- navigation.yml
  +-- other_procore_apis
A     +-- bim_web_viewer.md
D     +-- vdc_web_viewer.md
```
