### PR TITLE
[BIM] Add Header Links To Webviewer Doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,14 +108,33 @@ The project source files follow the [Github Flavored Markdown](https://github.gi
 * To add an internal link, use the `link` method provided by Jekyll, which ensures
 that links are valid and work both locally and remotely:
 
-```
+```md
 [Workflow API]({{ site.url }}{{ site.baseurl }}{% link tutorials/tutorial_workflows.md %})
 ````
 
 * To embed an external image, use the following syntax: `![alt text](url)`.
 * To embed an internal image, first save the image to the `assets/guides` folder and then embed them using a syntax like the following:
-```
+
+```md
 ![Install Architecture]({{ site.baseurl }}/assets/guides/iframe-install-arch.png)
+```
+
+### How to Add a Heading Link to a Heading
+
+Under the heading you'd like to link to you can add a snippet of inline html with an href that links to the heading. The heading ids are auto-generated as the `kebab-case` version of the heading content
+
+```md
+### Get Camera Position
+
+<p class="header-link-container"><a class="header-link" href="#get-camera-position"></a></p>
+```
+
+You could also use a [custom heading id](https://www.markdownguide.org/extended-syntax#heading-ids) if the id generation is giving you trouble:
+
+```md
+### Get Camera Position {#my-custom-id}
+
+<p class="header-link-container"><a class="header-link" href="#my-custom-id"></a></p>
 ```
 
 ## How to change the layout and CSS

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -93,30 +93,69 @@
       border-collapse: collapse;
       border-radius: 4px;
       margin-bottom: 10px;
-     }
+    }
 
-     tr {
-       border-bottom: 1px solid #d6dadc;
-     }
+    tr {
+      border-bottom: 1px solid #d6dadc;
+    }
 
-     td, th {
-       padding: 16px;
-     }
+    td, th {
+      padding: 16px;
+    }
 
-     th {
-       height: 48px;
-     }
+    th {
+      height: 48px;
+    }
 
-     blockquote {
-       margin: 16px 0px;
-           -webkit-box-align: center;
-           align-items: center;
-           border-left: 8px solid #e61920;
-           border-radius: 4px;
-           padding: 4px 16px;
-           box-shadow: #0000001a 0px 1px 3px 0px, #00000033 0px 1px 2px 0px;
-           background-color: #fef6f6;
-     }
+    blockquote {
+      margin: 16px 0px;
+      -webkit-box-align: center;
+      align-items: center;
+      border-left: 8px solid #e61920;
+      border-radius: 4px;
+      padding: 4px 16px;
+      box-shadow: #0000001a 0px 1px 3px 0px, #00000033 0px 1px 2px 0px;
+      background-color: #fef6f6;
+    }
+
+    /* Heading Links */
+    .heading-link-container {
+      padding: 10px 0;
+      position: relative;
+      margin-top: -52px;
+      height: 32px;
+    }
+
+    .heading-link-container:hover > .heading-link {
+      opacity: 1;
+    }
+
+    .heading-link {
+      font-size: 12px;
+      padding: 5px;
+      opacity: 0;
+      position: absolute;
+    }
+
+    .heading-link::before {
+      content: '\1f517'; /*link character*/
+    }
+
+    .heading-link:hover {
+      opacity: 1;
+    }
+
+    h2 + .heading-link-container > .heading-link {
+      transform: translate(-26px, 2px);
+    }
+    
+    h3 + .heading-link-container > .heading-link {
+      transform: translate(-26px, 0px);
+    }
+
+    h4 + .heading-link-container > .heading-link {
+      transform: translate(-26px, -2px);
+    }
   </style>
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/nav.css"/>
 </head>

--- a/other_procore_apis/bim_web_viewer.md
+++ b/other_procore_apis/bim_web_viewer.md
@@ -5,7 +5,44 @@ layout: default
 section_title: Other Procore APIs
 ---
 
+<!-- markdownlint-disable no-inline-html -->
+<style>
+  .header-link-container {
+    padding: 10px 0;
+    position: relative;
+    margin-top: -52px;
+    height: 32px;
+  }
+  .header-link-container:hover > .header-link {
+    visibility: visible;
+  }
+  .header-link {
+    font-size: 12px;
+    padding: 5px;
+    visibility: hidden;
+    position: absolute;
+  }
+  .header-link:hover {
+    visibility: visible;
+  }
+
+  h2 + .header-link-container > .header-link {
+    transform: translate(-26px, 2px);
+  }
+  h3 + .header-link-container > .header-link {
+    transform: translate(-26px, 0px);
+  }
+  h4 + .header-link-container > .header-link {
+    transform: translate(-26px, -2px);
+  }
+</style>
+
 ## Getting started
+
+<p class="header-link-container">
+  <a class="header-link" href="#getting-started">&#x1f517;</a>
+</p>
+
 
 The Procore BIM Web Viewer is a single distributable Javascript file.
 
@@ -19,15 +56,27 @@ See the [Options](#options) section for more detail on the options object.
 
 ## Other Considerations
 
+<p class="header-link-container">
+  <a class="header-link" href="#other-considerations">&#x1f517;</a>
+</p>
+
 The viewer does not render a background or color.
 You may set your own background color with CSS on any parent element that contains the viewer for that background color to be displayed.
 
 ## API Introduction
 
+<p class="header-link-container">
+  <a class="header-link" href="#api-introduction">&#x1f517;</a>
+</p>
+
 When the Webviewer SDK is loaded and parsed on your page, a new global object is added to your window with the key ProcoreBim.
 ProcoreBim contains a mix of both static and non static methods and are generally grouped into namespaces to indicate primary functionality.
 
 ### ProcoreBim Namespaces
+
+<p class="header-link-container">
+  <a class="header-link" href="#procorebim-namespaces">&#x1f517;</a>
+</p>
 
 | Namespace | Description                                                                                                    |
 | --------- | -------------------------------------------------------------------------------------------------------------- |
@@ -35,6 +84,10 @@ ProcoreBim contains a mix of both static and non static methods and are generall
 | Webviewer | Model viewer to be instanced and allows for data and camera access [Webviewer Namespace](#webviewer-namespace) |
 
 ### Webviewer Namespaces
+
+<p class="header-link-container">
+  <a class="header-link" href="#webviewer-namespaces">&#x1f517;</a>
+</p>
 
 | Namespace | Description                                                                                   |
 | --------- | --------------------------------------------------------------------------------------------- |
@@ -94,7 +147,15 @@ ProcoreBim.Cache.hasModel({
 
 ## General API
 
+<p class="header-link-container">
+  <a class="header-link" href="#general-api">&#x1f517;</a>
+</p>
+
 ### Starting the Webviewer
+
+<p class="header-link-container">
+  <a class="header-link" href="#starting-the-webviewer">&#x1f517;</a>
+</p>
 
 ```
 start();
@@ -147,7 +208,15 @@ None
 
 ## Camera Namespace
 
+<p class="header-link-container">
+  <a class="header-link" href="#camera-namespace">&#x1f517;</a>
+</p>
+
 ### Get Camera Position
+
+<p class="header-link-container">
+  <a class="header-link" href="#get-camera-position">&#x1f517;</a>
+</p>
 
 ```
 getPosition();
@@ -174,6 +243,10 @@ Camera
 ---
 
 ### Set Camera Position
+
+<p class="header-link-container">
+  <a class="header-link" href="#set-camera-position">&#x1f517;</a>
+</p>
 
 ```
 setPosition(x, y, z);
@@ -208,6 +281,10 @@ Camera
 
 ### Get Camera Direction
 
+<p class="header-link-container">
+  <a class="header-link" href="#get-camera-direction">&#x1f517;</a>
+</p>
+
 ```
 getCameraDirection();
 ```
@@ -233,6 +310,10 @@ Camera
 ---
 
 ### Set Camera Look At
+
+<p class="header-link-container">
+  <a class="header-link" href="#set-camera-look-at">&#x1f517;</a>
+</p>
 
 ```
 setLookAt(x, y, z);
@@ -267,6 +348,10 @@ Camera
 
 ### Get Screen Position
 
+<p class="header-link-container">
+  <a class="header-link" href="#get-screen-position">&#x1f517;</a>
+</p>
+
 ```
 getScreenPosition(x, y, z);
 ```
@@ -297,6 +382,10 @@ Camera
 
 ### Get Snapshot
 
+<p class="header-link-container">
+  <a class="header-link" href="#get-snapshot">&#x1f517;</a>
+</p>
+
 ```
 getSnapshot(color);
 ```
@@ -323,7 +412,11 @@ Camera
 
 ---
 
-## Set Camera From BCF Camera
+### Set Camera From BCF Camera
+
+<p class="header-link-container">
+  <a class="header-link" href="#set-camera-from-bcf-camera">&#x1f517;</a>
+</p>
 
 ```
 setBcfCamera(bcfCamera);
@@ -354,6 +447,10 @@ Camera
 
 ### Get BCF Camera From Camera
 
+<p class="header-link-container">
+  <a class="header-link" href="#get-bcf-camera-from-camera">&#x1f517;</a>
+</p>
+
 ```
 getBcfCamera();
 ```
@@ -379,7 +476,11 @@ Camera
 
 ---
 
-## Navigation to the home viewpoint
+### Navigation to the home viewpoint
+
+<p class="header-link-container">
+  <a class="header-link" href="#navigation-to-the-home-viewpoint">&#x1f517;</a>
+</p>
 
 ```
 navToHomeView();
@@ -405,7 +506,11 @@ Camera
 
 ---
 
-## Set Euler Angles
+### Set Euler Angles
+
+<p class="header-link-container">
+  <a class="header-link" href="#set-euler-angles">&#x1f517;</a>
+</p>
 
 ```
 setEulerAngles(x, y, z);
@@ -435,7 +540,15 @@ Camera
 
 ## DOM Namespace
 
+<p class="header-link-container">
+  <a class="header-link" href="#dom-namespace">&#x1f517;</a>
+</p>
+
 ### Add Panel
+
+<p class="header-link-container">
+  <a class="header-link" href="#add-panel">&#x1f517;</a>
+</p>
 
 ```
 addPanel(domElement);
@@ -465,6 +578,10 @@ Dom
 
 ### Remove Panel
 
+<p class="header-link-container">
+  <a class="header-link" href="#remove-panel">&#x1f517;</a>
+</p>
+
 ```
 removePanel(domElement);
 ```
@@ -490,6 +607,10 @@ boolean
 Dom
 
 ## Events Namespace
+
+<p class="header-link-container">
+  <a class="header-link" href="#events-namespace">&#x1f517;</a>
+</p>
 
 Supported events are:
 
@@ -535,6 +656,10 @@ Supported events are:
 
 ### Add Event
 
+<p class="header-link-container">
+  <a class="header-link" href="#add-event">&#x1f517;</a>
+</p>
+
 ```
 addEventListener(eventName, callback);
 ```
@@ -563,6 +688,10 @@ Events
 ---
 
 ### Remove Event
+
+<p class="header-link-container">
+  <a class="header-link" href="#remove-event">&#x1f517;</a>
+</p>
 
 ```
 removeEventListener(eventName, callback);
@@ -593,6 +722,10 @@ Events
 
 ### Dispatch Event
 
+<p class="header-link-container">
+  <a class="header-link" href="#dispatch-event">&#x1f517;</a>
+</p>
+
 ```
 dispatchEvent(eventName, callback);
 ```
@@ -620,7 +753,15 @@ Events
 
 ## Model Namespace
 
+<p class="header-link-container">
+  <a class="header-link" href="#model-namespace">&#x1f517;</a>
+</p>
+
 ### Get Object from object id
+
+<p class="header-link-container">
+  <a class="header-link" href="#get-object-from-object-id">&#x1f517;</a>
+</p>
 
 ```
 getObject(objectId);
@@ -648,6 +789,10 @@ Model
 
 ### Get Hidden ID's
 
+<p class="header-link-container">
+  <a class="header-link" href="#get-hidden-ids">&#x1f517;</a>
+</p>
+
 ```
 getHiddenGeoIds();
 ```
@@ -673,6 +818,10 @@ Model
 ---
 
 ### Add Hidden ID's
+
+<p class="header-link-container">
+  <a class="header-link" href="#add-hidden-ids">&#x1f517;</a>
+</p>
 
 ```
 addHiddenGeoIds(objectIds);
@@ -702,6 +851,10 @@ Model
 ---
 
 ### Has Hidden ID's
+
+<p class="header-link-container">
+  <a class="header-link" href="#has-hidden-ids">&#x1f517;</a>
+</p>
 
 ```
 hasHiddenGeoIds(objectIds);
@@ -733,6 +886,10 @@ Model
 
 ### Clear Hidden ID's
 
+<p class="header-link-container">
+  <a class="header-link" href="#clear-hidden-ids">&#x1f517;</a>
+</p>
+
 ```
 clearHiddenIds();
 ```
@@ -757,7 +914,11 @@ Model
 
 ---
 
-Get Selected ID's
+### Get Selected ID's
+
+<p class="header-link-container">
+  <a class="header-link" href="#get-selected-ids">&#x1f517;</a>
+</p>
 
 ```
 getSelectedGeoIds();
@@ -784,6 +945,10 @@ Model
 ---
 
 ### Add Selected ID's
+
+<p class="header-link-container">
+  <a class="header-link" href="#add-selected-ids">&#x1f517;</a>
+</p>
 
 ```
 addSelectedIds(objectIds);
@@ -813,6 +978,10 @@ Model
 ---
 
 ### Has Selected ID's
+
+<p class="header-link-container">
+  <a class="header-link" href="#has-selected-ids">&#x1f517;</a>
+</p>
 
 ```
 hasSelectedIds(objectIds);
@@ -844,6 +1013,10 @@ Model
 
 ### Clear Selected ID's
 
+<p class="header-link-container">
+  <a class="header-link" href="#clear-selected-ids">&#x1f517;</a>
+</p>
+
 ```
 clearSelectedIds();
 ```
@@ -869,6 +1042,10 @@ Model
 ---
 
 ### Set Object Color
+
+<p class="header-link-container">
+  <a class="header-link" href="#set-object-color">&#x1f517;</a>
+</p>
 
 ```
 setObjectColor(objectId, hexColor, opacity);
@@ -900,6 +1077,10 @@ Model
 
 ### Get Sections
 
+<p class="header-link-container">
+  <a class="header-link" href="#get-sections">&#x1f517;</a>
+</p>
+
 ```
 getSections();
 ```
@@ -923,6 +1104,10 @@ Model
 ---
 
 ### Set Section Box
+
+<p class="header-link-container">
+  <a class="header-link" href="#set-section-box">&#x1f517;</a>
+</p>
 
 ```
 setSectionBox(minXYZ, maxXYZ, rotation);
@@ -954,6 +1139,10 @@ Model
 
 ### Remove Section Box
 
+<p class="header-link-container">
+  <a class="header-link" href="#remove-section-box">&#x1f517;</a>
+</p>
+
 ```
 removeSectionBox();
 ```
@@ -979,6 +1168,10 @@ Model
 ---
 
 ### Add Section Plane
+
+<p class="header-link-container">
+  <a class="header-link" href="#add-section-plane">&#x1f517;</a>
+</p>
 
 ```
 addSectionPlane(distance, normal);
@@ -1009,6 +1202,10 @@ Model
 
 ### Remove Section Plane
 
+<p class="header-link-container">
+  <a class="header-link" href="#remove-section-plane">&#x1f517;</a>
+</p>
+
 ```
 removeSectionPlane(uuid);
 ```
@@ -1035,7 +1232,11 @@ Model
 
 ---
 
-### Remove Section Box
+### Clear Sections
+
+<p class="header-link-container">
+  <a class="header-link" href="#clear-sections">&#x1f517;</a>
+</p>
 
 ```
 clearSection();
@@ -1062,6 +1263,10 @@ Model
 ---
 
 ### Set Webviewer Configuration options
+
+<p class="header-link-container">
+  <a class="header-link" href="#set-webviewer-configuration-options">&#x1f517;</a>
+</p>
 
 ```
 setOptions(options);
@@ -1092,6 +1297,10 @@ Model
 ---
 
 ### Get relative planmap space position based on model space position
+
+<p class="header-link-container">
+  <a class="header-link" href="#get-relative-planmap-space-position-based-on-model-space-position">&#x1f517;</a>
+</p>
 
 ```
 MapToModelSpace(
@@ -1144,6 +1353,10 @@ Model
 
 ### Get relative model space position based on planmap space position
 
+<p class="header-link-container">
+  <a class="header-link" href="#get-relative-model-space-position-based-on-planmap-space-position">&#x1f517;</a>
+</p>
+
 ```
 ModelToMapSpace(
   point,
@@ -1195,6 +1408,10 @@ Model
 
 ### Get Global Offset
 
+<p class="header-link-container">
+  <a class="header-link" href="#get-global-offset">&#x1f517;</a>
+</p>
+
 ```
 getGlobalOffset();
 ```
@@ -1219,7 +1436,15 @@ Model
 
 ## Cache Namespace
 
+<p class="header-link-container">
+  <a class="header-link" href="#cache-namespace">&#x1f517;</a>
+</p>
+
 ### Is the model cached
+
+<p class="header-link-container">
+  <a class="header-link" href="#is-the-model-cached">&#x1f517;</a>
+</p>
 
 ```
 hasModel(urlsObject);
@@ -1258,6 +1483,10 @@ Promise(Boolean)
 
 ### Remove Model
 
+<p class="header-link-container">
+  <a class="header-link" href="#remove-model">&#x1f517;</a>
+</p>
+
 ```
 removeModel(urlsObject);
 ```
@@ -1292,6 +1521,10 @@ Promise(boolean)
 ```
 
 ## Options
+
+<p class="header-link-container">
+  <a class="header-link" href="#options">&#x1f517;</a>
+</p>
 
 `version [number]` (required)
 
@@ -1525,7 +1758,15 @@ See [Tools](#tools) for further information.
 
 ## Objects
 
+<p class="header-link-container">
+  <a class="header-link" href="#objects">&#x1f517;</a>
+</p>
+
 ### Perspective Camera Object
+
+<p class="header-link-container">
+  <a class="header-link" href="#perspective-camera-object">&#x1f517;</a>
+</p>
 
 ```
 {
@@ -1541,6 +1782,10 @@ See [Tools](#tools) for further information.
 
 ### Orthogonal Camera Object
 
+<p class="header-link-container">
+  <a class="header-link" href="#orthogonal-camera-object">&#x1f517;</a>
+</p>
+
 ```
 {
   orthogonal_camera: {
@@ -1555,6 +1800,10 @@ See [Tools](#tools) for further information.
 ```
 
 ### Model Object
+
+<p class="header-link-container">
+  <a class="header-link" href="#model-object">&#x1f517;</a>
+</p>
 
 ```
 {
@@ -1575,6 +1824,10 @@ See [Tools](#tools) for further information.
 
 ### Section Plane Object
 
+<p class="header-link-container">
+  <a class="header-link" href="#section-plane-object">&#x1f517;</a>
+</p>
+
 The key `plane` is an array of planes added.
 
 ```
@@ -1593,6 +1846,10 @@ The key `plane` is an array of planes added.
 
 ### Section Box Object
 
+<p class="header-link-container">
+  <a class="header-link" href="#section-box-object">&#x1f517;</a>
+</p>
+
 If `rotation` is applied, `rotation` will be represented as Euler angle of type Number.
 Otherwise, `rotation` will be undefined.
 
@@ -1610,6 +1867,10 @@ Otherwise, `rotation` will be undefined.
 
 ### Urls Object
 
+<p class="header-link-container">
+  <a class="header-link" href="#urls-object">&#x1f517;</a>
+</p>
+
 ```
 {
   meshUrl: String,
@@ -1621,7 +1882,15 @@ Otherwise, `rotation` will be undefined.
 
 ### Constants
 
+<p class="header-link-container">
+  <a class="header-link" href="#constants">&#x1f517;</a>
+</p>
+
 ### Tools
+
+<p class="header-link-container">
+  <a class="header-link" href="#tools">&#x1f517;</a>
+</p>
 
 `ProcoreBim.Webviewer.tools.{tool_type}`
 
@@ -1643,3 +1912,5 @@ Otherwise, `rotation` will be undefined.
 | Option      | Type    | Description                                                                                                                                         |
 | ----------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | center_lock | Boolean | Enables or disables the measurement navigation mode. Set to false if you don't want the navigation to change in anyway after a measurement is made. |
+
+<!-- markdownlint-enable no-inline-html -->

--- a/other_procore_apis/bim_web_viewer.md
+++ b/other_procore_apis/bim_web_viewer.md
@@ -14,19 +14,19 @@ section_title: Other Procore APIs
     height: 32px;
   }
   .header-link-container:hover > .header-link {
-    visibility: visible;
+    opacity: 1;
   }
   .header-link {
     font-size: 12px;
     padding: 5px;
-    visibility: hidden;
+    opacity: 0;
     position: absolute;
   }
   .header-link::before {
     content: '\1f517'; /*link character*/
   }
   .header-link:hover {
-    visibility: visible;
+    opacity: 1;
   }
 
   h2 + .header-link-container > .header-link {

--- a/other_procore_apis/bim_web_viewer.md
+++ b/other_procore_apis/bim_web_viewer.md
@@ -6,43 +6,10 @@ section_title: Other Procore APIs
 ---
 
 <!-- markdownlint-disable no-inline-html -->
-<style>
-  .header-link-container {
-    padding: 10px 0;
-    position: relative;
-    margin-top: -52px;
-    height: 32px;
-  }
-  .header-link-container:hover > .header-link {
-    opacity: 1;
-  }
-  .header-link {
-    font-size: 12px;
-    padding: 5px;
-    opacity: 0;
-    position: absolute;
-  }
-  .header-link::before {
-    content: '\1f517'; /*link character*/
-  }
-  .header-link:hover {
-    opacity: 1;
-  }
-
-  h2 + .header-link-container > .header-link {
-    transform: translate(-26px, 2px);
-  }
-  h3 + .header-link-container > .header-link {
-    transform: translate(-26px, 0px);
-  }
-  h4 + .header-link-container > .header-link {
-    transform: translate(-26px, -2px);
-  }
-</style>
 
 ## Getting started
 
-<p class="header-link-container"><a class="header-link" href="#getting-started"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#getting-started"></a></p>
 
 The Procore BIM Web Viewer is a single distributable Javascript file.
 
@@ -56,21 +23,21 @@ See the [Options](#options) section for more detail on the options object.
 
 ## Other Considerations
 
-<p class="header-link-container"><a class="header-link" href="#other-considerations"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#other-considerations"></a></p>
 
 The viewer does not render a background or color.
 You may set your own background color with CSS on any parent element that contains the viewer for that background color to be displayed.
 
 ## API Introduction
 
-<p class="header-link-container"><a class="header-link" href="#api-introduction"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#api-introduction"></a></p>
 
 When the Webviewer SDK is loaded and parsed on your page, a new global object is added to your window with the key ProcoreBim.
 ProcoreBim contains a mix of both static and non static methods and are generally grouped into namespaces to indicate primary functionality.
 
 ### ProcoreBim Namespaces
 
-<p class="header-link-container"><a class="header-link" href="#procorebim-namespaces"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#procorebim-namespaces"></a></p>
 
 | Namespace | Description                                                                                                    |
 | --------- | -------------------------------------------------------------------------------------------------------------- |
@@ -79,7 +46,7 @@ ProcoreBim contains a mix of both static and non static methods and are generall
 
 ### Webviewer Namespaces
 
-<p class="header-link-container"><a class="header-link" href="#webviewer-namespaces"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#webviewer-namespaces"></a></p>
 
 | Namespace | Description                                                                                   |
 | --------- | --------------------------------------------------------------------------------------------- |
@@ -139,11 +106,11 @@ ProcoreBim.Cache.hasModel({
 
 ## General API
 
-<p class="header-link-container"><a class="header-link" href="#general-api"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#general-api"></a></p>
 
 ### Starting the Webviewer
 
-<p class="header-link-container"><a class="header-link" href="#starting-the-webviewer"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#starting-the-webviewer"></a></p>
 
 ```
 start();
@@ -196,11 +163,11 @@ None
 
 ## Camera Namespace
 
-<p class="header-link-container"><a class="header-link" href="#camera-namespace"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#camera-namespace"></a></p>
 
 ### Get Camera Position
 
-<p class="header-link-container"><a class="header-link" href="#get-camera-position"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#get-camera-position"></a></p>
 
 ```
 getPosition();
@@ -228,7 +195,7 @@ Camera
 
 ### Set Camera Position
 
-<p class="header-link-container"><a class="header-link" href="#set-camera-position"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#set-camera-position"></a></p>
 
 ```
 setPosition(x, y, z);
@@ -263,7 +230,7 @@ Camera
 
 ### Get Camera Direction
 
-<p class="header-link-container"><a class="header-link" href="#get-camera-direction"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#get-camera-direction"></a></p>
 
 ```
 getCameraDirection();
@@ -291,7 +258,7 @@ Camera
 
 ### Set Camera Look At
 
-<p class="header-link-container"><a class="header-link" href="#set-camera-look-at"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#set-camera-look-at"></a></p>
 
 ```
 setLookAt(x, y, z);
@@ -326,7 +293,7 @@ Camera
 
 ### Get Screen Position
 
-<p class="header-link-container"><a class="header-link" href="#get-screen-position"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#get-screen-position"></a></p>
 
 ```
 getScreenPosition(x, y, z);
@@ -358,7 +325,7 @@ Camera
 
 ### Get Snapshot
 
-<p class="header-link-container"><a class="header-link" href="#get-snapshot"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#get-snapshot"></a></p>
 
 ```
 getSnapshot(color);
@@ -388,7 +355,7 @@ Camera
 
 ### Set Camera From BCF Camera
 
-<p class="header-link-container"><a class="header-link" href="#set-camera-from-bcf-camera"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#set-camera-from-bcf-camera"></a></p>
 
 ```
 setBcfCamera(bcfCamera);
@@ -419,7 +386,7 @@ Camera
 
 ### Get BCF Camera From Camera
 
-<p class="header-link-container"><a class="header-link" href="#get-bcf-camera-from-camera"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#get-bcf-camera-from-camera"></a></p>
 
 ```
 getBcfCamera();
@@ -448,7 +415,7 @@ Camera
 
 ### Navigation to the home viewpoint
 
-<p class="header-link-container"><a class="header-link" href="#navigation-to-the-home-viewpoint"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#navigation-to-the-home-viewpoint"></a></p>
 
 ```
 navToHomeView();
@@ -476,7 +443,7 @@ Camera
 
 ### Set Euler Angles
 
-<p class="header-link-container"><a class="header-link" href="#set-euler-angles"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#set-euler-angles"></a></p>
 
 ```
 setEulerAngles(x, y, z);
@@ -506,11 +473,11 @@ Camera
 
 ## DOM Namespace
 
-<p class="header-link-container"><a class="header-link" href="#dom-namespace"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#dom-namespace"></a></p>
 
 ### Add Panel
 
-<p class="header-link-container"><a class="header-link" href="#add-panel"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#add-panel"></a></p>
 
 ```
 addPanel(domElement);
@@ -540,7 +507,7 @@ Dom
 
 ### Remove Panel
 
-<p class="header-link-container"><a class="header-link" href="#remove-panel"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#remove-panel"></a></p>
 
 ```
 removePanel(domElement);
@@ -568,7 +535,7 @@ Dom
 
 ## Events Namespace
 
-<p class="header-link-container"><a class="header-link" href="#events-namespace"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#events-namespace"></a></p>
 
 Supported events are:
 
@@ -614,7 +581,7 @@ Supported events are:
 
 ### Add Event
 
-<p class="header-link-container"><a class="header-link" href="#add-event"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#add-event"></a></p>
 
 ```
 addEventListener(eventName, callback);
@@ -645,7 +612,7 @@ Events
 
 ### Remove Event
 
-<p class="header-link-container"><a class="header-link" href="#remove-event"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#remove-event"></a></p>
 
 ```
 removeEventListener(eventName, callback);
@@ -676,7 +643,7 @@ Events
 
 ### Dispatch Event
 
-<p class="header-link-container"><a class="header-link" href="#dispatch-event"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#dispatch-event"></a></p>
 
 ```
 dispatchEvent(eventName, callback);
@@ -705,11 +672,11 @@ Events
 
 ## Model Namespace
 
-<p class="header-link-container"><a class="header-link" href="#model-namespace"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#model-namespace"></a></p>
 
 ### Get Object from object id
 
-<p class="header-link-container"><a class="header-link" href="#get-object-from-object-id"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#get-object-from-object-id"></a></p>
 
 ```
 getObject(objectId);
@@ -737,7 +704,7 @@ Model
 
 ### Get Hidden ID's
 
-<p class="header-link-container"><a class="header-link" href="#get-hidden-ids"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#get-hidden-ids"></a></p>
 
 ```
 getHiddenGeoIds();
@@ -765,7 +732,7 @@ Model
 
 ### Add Hidden ID's
 
-<p class="header-link-container"><a class="header-link" href="#add-hidden-ids"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#add-hidden-ids"></a></p>
 
 ```
 addHiddenGeoIds(objectIds);
@@ -796,7 +763,7 @@ Model
 
 ### Has Hidden ID's
 
-<p class="header-link-container"><a class="header-link" href="#has-hidden-ids"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#has-hidden-ids"></a></p>
 
 ```
 hasHiddenGeoIds(objectIds);
@@ -828,7 +795,7 @@ Model
 
 ### Clear Hidden ID's
 
-<p class="header-link-container"><a class="header-link" href="#clear-hidden-ids"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#clear-hidden-ids"></a></p>
 
 ```
 clearHiddenIds();
@@ -856,7 +823,7 @@ Model
 
 ### Get Selected ID's
 
-<p class="header-link-container"><a class="header-link" href="#get-selected-ids"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#get-selected-ids"></a></p>
 
 ```
 getSelectedGeoIds();
@@ -884,7 +851,7 @@ Model
 
 ### Add Selected ID's
 
-<p class="header-link-container"><a class="header-link" href="#add-selected-ids"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#add-selected-ids"></a></p>
 
 ```
 addSelectedIds(objectIds);
@@ -915,7 +882,7 @@ Model
 
 ### Has Selected ID's
 
-<p class="header-link-container"><a class="header-link" href="#has-selected-ids"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#has-selected-ids"></a></p>
 
 ```
 hasSelectedIds(objectIds);
@@ -947,7 +914,7 @@ Model
 
 ### Clear Selected ID's
 
-<p class="header-link-container"><a class="header-link" href="#clear-selected-ids"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#clear-selected-ids"></a></p>
 
 ```
 clearSelectedIds();
@@ -975,7 +942,7 @@ Model
 
 ### Set Object Color
 
-<p class="header-link-container"><a class="header-link" href="#set-object-color"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#set-object-color"></a></p>
 
 ```
 setObjectColor(objectId, hexColor, opacity);
@@ -1007,7 +974,7 @@ Model
 
 ### Get Sections
 
-<p class="header-link-container"><a class="header-link" href="#get-sections"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#get-sections"></a></p>
 
 ```
 getSections();
@@ -1033,7 +1000,7 @@ Model
 
 ### Set Section Box
 
-<p class="header-link-container"><a class="header-link" href="#set-section-box"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#set-section-box"></a></p>
 
 ```
 setSectionBox(minXYZ, maxXYZ, rotation);
@@ -1065,7 +1032,7 @@ Model
 
 ### Remove Section Box
 
-<p class="header-link-container"><a class="header-link" href="#remove-section-box"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#remove-section-box"></a></p>
 
 ```
 removeSectionBox();
@@ -1093,7 +1060,7 @@ Model
 
 ### Add Section Plane
 
-<p class="header-link-container"><a class="header-link" href="#add-section-plane"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#add-section-plane"></a></p>
 
 ```
 addSectionPlane(distance, normal);
@@ -1124,7 +1091,7 @@ Model
 
 ### Remove Section Plane
 
-<p class="header-link-container"><a class="header-link" href="#remove-section-plane"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#remove-section-plane"></a></p>
 
 ```
 removeSectionPlane(uuid);
@@ -1154,7 +1121,7 @@ Model
 
 ### Clear Sections
 
-<p class="header-link-container"><a class="header-link" href="#clear-sections"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#clear-sections"></a></p>
 
 ```
 clearSection();
@@ -1182,7 +1149,7 @@ Model
 
 ### Set Webviewer Configuration options
 
-<p class="header-link-container"><a class="header-link" href="#set-webviewer-configuration-options"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#set-webviewer-configuration-options"></a></p>
 
 ```
 setOptions(options);
@@ -1214,7 +1181,7 @@ Model
 
 ### Get relative planmap space position based on model space position
 
-<p class="header-link-container"><a class="header-link" href="#get-relative-planmap-space-position-based-on-model-space-position"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#get-relative-planmap-space-position-based-on-model-space-position"></a></p>
 
 ```
 MapToModelSpace(
@@ -1267,7 +1234,7 @@ Model
 
 ### Get relative model space position based on planmap space position
 
-<p class="header-link-container"><a class="header-link" href="#get-relative-model-space-position-based-on-planmap-space-position"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#get-relative-model-space-position-based-on-planmap-space-position"></a></p>
 
 ```
 ModelToMapSpace(
@@ -1320,7 +1287,7 @@ Model
 
 ### Get Global Offset
 
-<p class="header-link-container"><a class="header-link" href="#get-global-offset"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#get-global-offset"></a></p>
 
 ```
 getGlobalOffset();
@@ -1346,11 +1313,11 @@ Model
 
 ## Cache Namespace
 
-<p class="header-link-container"><a class="header-link" href="#cache-namespace"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#cache-namespace"></a></p>
 
 ### Is the model cached
 
-<p class="header-link-container"><a class="header-link" href="#is-the-model-cached"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#is-the-model-cached"></a></p>
 
 ```
 hasModel(urlsObject);
@@ -1389,7 +1356,7 @@ Promise(Boolean)
 
 ### Remove Model
 
-<p class="header-link-container"><a class="header-link" href="#remove-model"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#remove-model"></a></p>
 
 ```
 removeModel(urlsObject);
@@ -1426,7 +1393,7 @@ Promise(boolean)
 
 ## Options
 
-<p class="header-link-container"><a class="header-link" href="#options"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#options"></a></p>
 
 `version [number]` (required)
 
@@ -1660,11 +1627,11 @@ See [Tools](#tools) for further information.
 
 ## Objects
 
-<p class="header-link-container"><a class="header-link" href="#objects"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#objects"></a></p>
 
 ### Perspective Camera Object
 
-<p class="header-link-container"><a class="header-link" href="#perspective-camera-object"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#perspective-camera-object"></a></p>
 
 ```
 {
@@ -1680,7 +1647,7 @@ See [Tools](#tools) for further information.
 
 ### Orthogonal Camera Object
 
-<p class="header-link-container"><a class="header-link" href="#orthogonal-camera-object"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#orthogonal-camera-object"></a></p>
 
 ```
 {
@@ -1697,8 +1664,8 @@ See [Tools](#tools) for further information.
 
 ### Model Object
 
-<p class="header-link-container">
-  <a class="header-link" href="#model-object"></a>
+<p class="heading-link-container">
+  <a class="heading-link" href="#model-object"></a>
 </p>
 
 ```
@@ -1720,8 +1687,8 @@ See [Tools](#tools) for further information.
 
 ### Section Plane Object
 
-<p class="header-link-container">
-  <a class="header-link" href="#section-plane-object"></a>
+<p class="heading-link-container">
+  <a class="heading-link" href="#section-plane-object"></a>
 </p>
 
 The key `plane` is an array of planes added.
@@ -1742,8 +1709,8 @@ The key `plane` is an array of planes added.
 
 ### Section Box Object
 
-<p class="header-link-container">
-  <a class="header-link" href="#section-box-object"></a>
+<p class="heading-link-container">
+  <a class="heading-link" href="#section-box-object"></a>
 </p>
 
 If `rotation` is applied, `rotation` will be represented as Euler angle of type Number.
@@ -1763,8 +1730,8 @@ Otherwise, `rotation` will be undefined.
 
 ### Urls Object
 
-<p class="header-link-container">
-  <a class="header-link" href="#urls-object"></a>
+<p class="heading-link-container">
+  <a class="heading-link" href="#urls-object"></a>
 </p>
 
 ```
@@ -1778,14 +1745,14 @@ Otherwise, `rotation` will be undefined.
 
 ### Constants
 
-<p class="header-link-container">
-  <a class="header-link" href="#constants"></a>
+<p class="heading-link-container">
+  <a class="heading-link" href="#constants"></a>
 </p>
 
 ### Tools
 
-<p class="header-link-container">
-  <a class="header-link" href="#tools"></a>
+<p class="heading-link-container">
+  <a class="heading-link" href="#tools"></a>
 </p>
 
 `ProcoreBim.Webviewer.tools.{tool_type}`

--- a/other_procore_apis/bim_web_viewer.md
+++ b/other_procore_apis/bim_web_viewer.md
@@ -22,6 +22,9 @@ section_title: Other Procore APIs
     visibility: hidden;
     position: absolute;
   }
+  .header-link::before {
+    content: '\1f517'; /*link character*/
+  }
   .header-link:hover {
     visibility: visible;
   }
@@ -40,9 +43,8 @@ section_title: Other Procore APIs
 ## Getting started
 
 <p class="header-link-container">
-  <a class="header-link" href="#getting-started">&#x1f517;</a>
+  <a class="header-link" href="#getting-started"></a>
 </p>
-
 
 The Procore BIM Web Viewer is a single distributable Javascript file.
 
@@ -57,7 +59,7 @@ See the [Options](#options) section for more detail on the options object.
 ## Other Considerations
 
 <p class="header-link-container">
-  <a class="header-link" href="#other-considerations">&#x1f517;</a>
+  <a class="header-link" href="#other-considerations"></a>
 </p>
 
 The viewer does not render a background or color.
@@ -66,7 +68,7 @@ You may set your own background color with CSS on any parent element that contai
 ## API Introduction
 
 <p class="header-link-container">
-  <a class="header-link" href="#api-introduction">&#x1f517;</a>
+  <a class="header-link" href="#api-introduction"></a>
 </p>
 
 When the Webviewer SDK is loaded and parsed on your page, a new global object is added to your window with the key ProcoreBim.
@@ -75,7 +77,7 @@ ProcoreBim contains a mix of both static and non static methods and are generall
 ### ProcoreBim Namespaces
 
 <p class="header-link-container">
-  <a class="header-link" href="#procorebim-namespaces">&#x1f517;</a>
+  <a class="header-link" href="#procorebim-namespaces"></a>
 </p>
 
 | Namespace | Description                                                                                                    |
@@ -86,7 +88,7 @@ ProcoreBim contains a mix of both static and non static methods and are generall
 ### Webviewer Namespaces
 
 <p class="header-link-container">
-  <a class="header-link" href="#webviewer-namespaces">&#x1f517;</a>
+  <a class="header-link" href="#webviewer-namespaces"></a>
 </p>
 
 | Namespace | Description                                                                                   |
@@ -148,13 +150,13 @@ ProcoreBim.Cache.hasModel({
 ## General API
 
 <p class="header-link-container">
-  <a class="header-link" href="#general-api">&#x1f517;</a>
+  <a class="header-link" href="#general-api"></a>
 </p>
 
 ### Starting the Webviewer
 
 <p class="header-link-container">
-  <a class="header-link" href="#starting-the-webviewer">&#x1f517;</a>
+  <a class="header-link" href="#starting-the-webviewer"></a>
 </p>
 
 ```
@@ -209,13 +211,13 @@ None
 ## Camera Namespace
 
 <p class="header-link-container">
-  <a class="header-link" href="#camera-namespace">&#x1f517;</a>
+  <a class="header-link" href="#camera-namespace"></a>
 </p>
 
 ### Get Camera Position
 
 <p class="header-link-container">
-  <a class="header-link" href="#get-camera-position">&#x1f517;</a>
+  <a class="header-link" href="#get-camera-position"></a>
 </p>
 
 ```
@@ -245,7 +247,7 @@ Camera
 ### Set Camera Position
 
 <p class="header-link-container">
-  <a class="header-link" href="#set-camera-position">&#x1f517;</a>
+  <a class="header-link" href="#set-camera-position"></a>
 </p>
 
 ```
@@ -282,7 +284,7 @@ Camera
 ### Get Camera Direction
 
 <p class="header-link-container">
-  <a class="header-link" href="#get-camera-direction">&#x1f517;</a>
+  <a class="header-link" href="#get-camera-direction"></a>
 </p>
 
 ```
@@ -312,7 +314,7 @@ Camera
 ### Set Camera Look At
 
 <p class="header-link-container">
-  <a class="header-link" href="#set-camera-look-at">&#x1f517;</a>
+  <a class="header-link" href="#set-camera-look-at"></a>
 </p>
 
 ```
@@ -349,7 +351,7 @@ Camera
 ### Get Screen Position
 
 <p class="header-link-container">
-  <a class="header-link" href="#get-screen-position">&#x1f517;</a>
+  <a class="header-link" href="#get-screen-position"></a>
 </p>
 
 ```
@@ -383,7 +385,7 @@ Camera
 ### Get Snapshot
 
 <p class="header-link-container">
-  <a class="header-link" href="#get-snapshot">&#x1f517;</a>
+  <a class="header-link" href="#get-snapshot"></a>
 </p>
 
 ```
@@ -415,7 +417,7 @@ Camera
 ### Set Camera From BCF Camera
 
 <p class="header-link-container">
-  <a class="header-link" href="#set-camera-from-bcf-camera">&#x1f517;</a>
+  <a class="header-link" href="#set-camera-from-bcf-camera"></a>
 </p>
 
 ```
@@ -448,7 +450,7 @@ Camera
 ### Get BCF Camera From Camera
 
 <p class="header-link-container">
-  <a class="header-link" href="#get-bcf-camera-from-camera">&#x1f517;</a>
+  <a class="header-link" href="#get-bcf-camera-from-camera"></a>
 </p>
 
 ```
@@ -479,7 +481,7 @@ Camera
 ### Navigation to the home viewpoint
 
 <p class="header-link-container">
-  <a class="header-link" href="#navigation-to-the-home-viewpoint">&#x1f517;</a>
+  <a class="header-link" href="#navigation-to-the-home-viewpoint"></a>
 </p>
 
 ```
@@ -509,7 +511,7 @@ Camera
 ### Set Euler Angles
 
 <p class="header-link-container">
-  <a class="header-link" href="#set-euler-angles">&#x1f517;</a>
+  <a class="header-link" href="#set-euler-angles"></a>
 </p>
 
 ```
@@ -541,13 +543,13 @@ Camera
 ## DOM Namespace
 
 <p class="header-link-container">
-  <a class="header-link" href="#dom-namespace">&#x1f517;</a>
+  <a class="header-link" href="#dom-namespace"></a>
 </p>
 
 ### Add Panel
 
 <p class="header-link-container">
-  <a class="header-link" href="#add-panel">&#x1f517;</a>
+  <a class="header-link" href="#add-panel"></a>
 </p>
 
 ```
@@ -579,7 +581,7 @@ Dom
 ### Remove Panel
 
 <p class="header-link-container">
-  <a class="header-link" href="#remove-panel">&#x1f517;</a>
+  <a class="header-link" href="#remove-panel"></a>
 </p>
 
 ```
@@ -609,7 +611,7 @@ Dom
 ## Events Namespace
 
 <p class="header-link-container">
-  <a class="header-link" href="#events-namespace">&#x1f517;</a>
+  <a class="header-link" href="#events-namespace"></a>
 </p>
 
 Supported events are:
@@ -657,7 +659,7 @@ Supported events are:
 ### Add Event
 
 <p class="header-link-container">
-  <a class="header-link" href="#add-event">&#x1f517;</a>
+  <a class="header-link" href="#add-event"></a>
 </p>
 
 ```
@@ -690,7 +692,7 @@ Events
 ### Remove Event
 
 <p class="header-link-container">
-  <a class="header-link" href="#remove-event">&#x1f517;</a>
+  <a class="header-link" href="#remove-event"></a>
 </p>
 
 ```
@@ -723,7 +725,7 @@ Events
 ### Dispatch Event
 
 <p class="header-link-container">
-  <a class="header-link" href="#dispatch-event">&#x1f517;</a>
+  <a class="header-link" href="#dispatch-event"></a>
 </p>
 
 ```
@@ -754,13 +756,13 @@ Events
 ## Model Namespace
 
 <p class="header-link-container">
-  <a class="header-link" href="#model-namespace">&#x1f517;</a>
+  <a class="header-link" href="#model-namespace"></a>
 </p>
 
 ### Get Object from object id
 
 <p class="header-link-container">
-  <a class="header-link" href="#get-object-from-object-id">&#x1f517;</a>
+  <a class="header-link" href="#get-object-from-object-id"></a>
 </p>
 
 ```
@@ -790,7 +792,7 @@ Model
 ### Get Hidden ID's
 
 <p class="header-link-container">
-  <a class="header-link" href="#get-hidden-ids">&#x1f517;</a>
+  <a class="header-link" href="#get-hidden-ids"></a>
 </p>
 
 ```
@@ -820,7 +822,7 @@ Model
 ### Add Hidden ID's
 
 <p class="header-link-container">
-  <a class="header-link" href="#add-hidden-ids">&#x1f517;</a>
+  <a class="header-link" href="#add-hidden-ids"></a>
 </p>
 
 ```
@@ -853,7 +855,7 @@ Model
 ### Has Hidden ID's
 
 <p class="header-link-container">
-  <a class="header-link" href="#has-hidden-ids">&#x1f517;</a>
+  <a class="header-link" href="#has-hidden-ids"></a>
 </p>
 
 ```
@@ -887,7 +889,7 @@ Model
 ### Clear Hidden ID's
 
 <p class="header-link-container">
-  <a class="header-link" href="#clear-hidden-ids">&#x1f517;</a>
+  <a class="header-link" href="#clear-hidden-ids"></a>
 </p>
 
 ```
@@ -917,7 +919,7 @@ Model
 ### Get Selected ID's
 
 <p class="header-link-container">
-  <a class="header-link" href="#get-selected-ids">&#x1f517;</a>
+  <a class="header-link" href="#get-selected-ids"></a>
 </p>
 
 ```
@@ -947,7 +949,7 @@ Model
 ### Add Selected ID's
 
 <p class="header-link-container">
-  <a class="header-link" href="#add-selected-ids">&#x1f517;</a>
+  <a class="header-link" href="#add-selected-ids"></a>
 </p>
 
 ```
@@ -980,7 +982,7 @@ Model
 ### Has Selected ID's
 
 <p class="header-link-container">
-  <a class="header-link" href="#has-selected-ids">&#x1f517;</a>
+  <a class="header-link" href="#has-selected-ids"></a>
 </p>
 
 ```
@@ -1014,7 +1016,7 @@ Model
 ### Clear Selected ID's
 
 <p class="header-link-container">
-  <a class="header-link" href="#clear-selected-ids">&#x1f517;</a>
+  <a class="header-link" href="#clear-selected-ids"></a>
 </p>
 
 ```
@@ -1044,7 +1046,7 @@ Model
 ### Set Object Color
 
 <p class="header-link-container">
-  <a class="header-link" href="#set-object-color">&#x1f517;</a>
+  <a class="header-link" href="#set-object-color"></a>
 </p>
 
 ```
@@ -1078,7 +1080,7 @@ Model
 ### Get Sections
 
 <p class="header-link-container">
-  <a class="header-link" href="#get-sections">&#x1f517;</a>
+  <a class="header-link" href="#get-sections"></a>
 </p>
 
 ```
@@ -1106,7 +1108,7 @@ Model
 ### Set Section Box
 
 <p class="header-link-container">
-  <a class="header-link" href="#set-section-box">&#x1f517;</a>
+  <a class="header-link" href="#set-section-box"></a>
 </p>
 
 ```
@@ -1140,7 +1142,7 @@ Model
 ### Remove Section Box
 
 <p class="header-link-container">
-  <a class="header-link" href="#remove-section-box">&#x1f517;</a>
+  <a class="header-link" href="#remove-section-box"></a>
 </p>
 
 ```
@@ -1170,7 +1172,7 @@ Model
 ### Add Section Plane
 
 <p class="header-link-container">
-  <a class="header-link" href="#add-section-plane">&#x1f517;</a>
+  <a class="header-link" href="#add-section-plane"></a>
 </p>
 
 ```
@@ -1203,7 +1205,7 @@ Model
 ### Remove Section Plane
 
 <p class="header-link-container">
-  <a class="header-link" href="#remove-section-plane">&#x1f517;</a>
+  <a class="header-link" href="#remove-section-plane"></a>
 </p>
 
 ```
@@ -1235,7 +1237,7 @@ Model
 ### Clear Sections
 
 <p class="header-link-container">
-  <a class="header-link" href="#clear-sections">&#x1f517;</a>
+  <a class="header-link" href="#clear-sections"></a>
 </p>
 
 ```
@@ -1265,7 +1267,7 @@ Model
 ### Set Webviewer Configuration options
 
 <p class="header-link-container">
-  <a class="header-link" href="#set-webviewer-configuration-options">&#x1f517;</a>
+  <a class="header-link" href="#set-webviewer-configuration-options"></a>
 </p>
 
 ```
@@ -1299,7 +1301,7 @@ Model
 ### Get relative planmap space position based on model space position
 
 <p class="header-link-container">
-  <a class="header-link" href="#get-relative-planmap-space-position-based-on-model-space-position">&#x1f517;</a>
+  <a class="header-link" href="#get-relative-planmap-space-position-based-on-model-space-position"></a>
 </p>
 
 ```
@@ -1354,7 +1356,7 @@ Model
 ### Get relative model space position based on planmap space position
 
 <p class="header-link-container">
-  <a class="header-link" href="#get-relative-model-space-position-based-on-planmap-space-position">&#x1f517;</a>
+  <a class="header-link" href="#get-relative-model-space-position-based-on-planmap-space-position"></a>
 </p>
 
 ```
@@ -1409,7 +1411,7 @@ Model
 ### Get Global Offset
 
 <p class="header-link-container">
-  <a class="header-link" href="#get-global-offset">&#x1f517;</a>
+  <a class="header-link" href="#get-global-offset"></a>
 </p>
 
 ```
@@ -1437,13 +1439,13 @@ Model
 ## Cache Namespace
 
 <p class="header-link-container">
-  <a class="header-link" href="#cache-namespace">&#x1f517;</a>
+  <a class="header-link" href="#cache-namespace"></a>
 </p>
 
 ### Is the model cached
 
 <p class="header-link-container">
-  <a class="header-link" href="#is-the-model-cached">&#x1f517;</a>
+  <a class="header-link" href="#is-the-model-cached"></a>
 </p>
 
 ```
@@ -1484,7 +1486,7 @@ Promise(Boolean)
 ### Remove Model
 
 <p class="header-link-container">
-  <a class="header-link" href="#remove-model">&#x1f517;</a>
+  <a class="header-link" href="#remove-model"></a>
 </p>
 
 ```
@@ -1523,7 +1525,7 @@ Promise(boolean)
 ## Options
 
 <p class="header-link-container">
-  <a class="header-link" href="#options">&#x1f517;</a>
+  <a class="header-link" href="#options"></a>
 </p>
 
 `version [number]` (required)
@@ -1759,13 +1761,13 @@ See [Tools](#tools) for further information.
 ## Objects
 
 <p class="header-link-container">
-  <a class="header-link" href="#objects">&#x1f517;</a>
+  <a class="header-link" href="#objects"></a>
 </p>
 
 ### Perspective Camera Object
 
 <p class="header-link-container">
-  <a class="header-link" href="#perspective-camera-object">&#x1f517;</a>
+  <a class="header-link" href="#perspective-camera-object"></a>
 </p>
 
 ```
@@ -1783,7 +1785,7 @@ See [Tools](#tools) for further information.
 ### Orthogonal Camera Object
 
 <p class="header-link-container">
-  <a class="header-link" href="#orthogonal-camera-object">&#x1f517;</a>
+  <a class="header-link" href="#orthogonal-camera-object"></a>
 </p>
 
 ```
@@ -1802,7 +1804,7 @@ See [Tools](#tools) for further information.
 ### Model Object
 
 <p class="header-link-container">
-  <a class="header-link" href="#model-object">&#x1f517;</a>
+  <a class="header-link" href="#model-object"></a>
 </p>
 
 ```
@@ -1825,7 +1827,7 @@ See [Tools](#tools) for further information.
 ### Section Plane Object
 
 <p class="header-link-container">
-  <a class="header-link" href="#section-plane-object">&#x1f517;</a>
+  <a class="header-link" href="#section-plane-object"></a>
 </p>
 
 The key `plane` is an array of planes added.
@@ -1847,7 +1849,7 @@ The key `plane` is an array of planes added.
 ### Section Box Object
 
 <p class="header-link-container">
-  <a class="header-link" href="#section-box-object">&#x1f517;</a>
+  <a class="header-link" href="#section-box-object"></a>
 </p>
 
 If `rotation` is applied, `rotation` will be represented as Euler angle of type Number.
@@ -1868,7 +1870,7 @@ Otherwise, `rotation` will be undefined.
 ### Urls Object
 
 <p class="header-link-container">
-  <a class="header-link" href="#urls-object">&#x1f517;</a>
+  <a class="header-link" href="#urls-object"></a>
 </p>
 
 ```
@@ -1883,13 +1885,13 @@ Otherwise, `rotation` will be undefined.
 ### Constants
 
 <p class="header-link-container">
-  <a class="header-link" href="#constants">&#x1f517;</a>
+  <a class="header-link" href="#constants"></a>
 </p>
 
 ### Tools
 
 <p class="header-link-container">
-  <a class="header-link" href="#tools">&#x1f517;</a>
+  <a class="header-link" href="#tools"></a>
 </p>
 
 `ProcoreBim.Webviewer.tools.{tool_type}`

--- a/other_procore_apis/bim_web_viewer.md
+++ b/other_procore_apis/bim_web_viewer.md
@@ -42,9 +42,7 @@ section_title: Other Procore APIs
 
 ## Getting started
 
-<p class="header-link-container">
-  <a class="header-link" href="#getting-started"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#getting-started"></a></p>
 
 The Procore BIM Web Viewer is a single distributable Javascript file.
 
@@ -58,27 +56,21 @@ See the [Options](#options) section for more detail on the options object.
 
 ## Other Considerations
 
-<p class="header-link-container">
-  <a class="header-link" href="#other-considerations"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#other-considerations"></a></p>
 
 The viewer does not render a background or color.
 You may set your own background color with CSS on any parent element that contains the viewer for that background color to be displayed.
 
 ## API Introduction
 
-<p class="header-link-container">
-  <a class="header-link" href="#api-introduction"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#api-introduction"></a></p>
 
 When the Webviewer SDK is loaded and parsed on your page, a new global object is added to your window with the key ProcoreBim.
 ProcoreBim contains a mix of both static and non static methods and are generally grouped into namespaces to indicate primary functionality.
 
 ### ProcoreBim Namespaces
 
-<p class="header-link-container">
-  <a class="header-link" href="#procorebim-namespaces"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#procorebim-namespaces"></a></p>
 
 | Namespace | Description                                                                                                    |
 | --------- | -------------------------------------------------------------------------------------------------------------- |
@@ -87,9 +79,7 @@ ProcoreBim contains a mix of both static and non static methods and are generall
 
 ### Webviewer Namespaces
 
-<p class="header-link-container">
-  <a class="header-link" href="#webviewer-namespaces"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#webviewer-namespaces"></a></p>
 
 | Namespace | Description                                                                                   |
 | --------- | --------------------------------------------------------------------------------------------- |
@@ -149,15 +139,11 @@ ProcoreBim.Cache.hasModel({
 
 ## General API
 
-<p class="header-link-container">
-  <a class="header-link" href="#general-api"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#general-api"></a></p>
 
 ### Starting the Webviewer
 
-<p class="header-link-container">
-  <a class="header-link" href="#starting-the-webviewer"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#starting-the-webviewer"></a></p>
 
 ```
 start();
@@ -210,15 +196,11 @@ None
 
 ## Camera Namespace
 
-<p class="header-link-container">
-  <a class="header-link" href="#camera-namespace"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#camera-namespace"></a></p>
 
 ### Get Camera Position
 
-<p class="header-link-container">
-  <a class="header-link" href="#get-camera-position"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#get-camera-position"></a></p>
 
 ```
 getPosition();
@@ -246,9 +228,7 @@ Camera
 
 ### Set Camera Position
 
-<p class="header-link-container">
-  <a class="header-link" href="#set-camera-position"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#set-camera-position"></a></p>
 
 ```
 setPosition(x, y, z);
@@ -283,9 +263,7 @@ Camera
 
 ### Get Camera Direction
 
-<p class="header-link-container">
-  <a class="header-link" href="#get-camera-direction"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#get-camera-direction"></a></p>
 
 ```
 getCameraDirection();
@@ -313,9 +291,7 @@ Camera
 
 ### Set Camera Look At
 
-<p class="header-link-container">
-  <a class="header-link" href="#set-camera-look-at"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#set-camera-look-at"></a></p>
 
 ```
 setLookAt(x, y, z);
@@ -350,9 +326,7 @@ Camera
 
 ### Get Screen Position
 
-<p class="header-link-container">
-  <a class="header-link" href="#get-screen-position"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#get-screen-position"></a></p>
 
 ```
 getScreenPosition(x, y, z);
@@ -384,9 +358,7 @@ Camera
 
 ### Get Snapshot
 
-<p class="header-link-container">
-  <a class="header-link" href="#get-snapshot"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#get-snapshot"></a></p>
 
 ```
 getSnapshot(color);
@@ -416,9 +388,7 @@ Camera
 
 ### Set Camera From BCF Camera
 
-<p class="header-link-container">
-  <a class="header-link" href="#set-camera-from-bcf-camera"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#set-camera-from-bcf-camera"></a></p>
 
 ```
 setBcfCamera(bcfCamera);
@@ -449,9 +419,7 @@ Camera
 
 ### Get BCF Camera From Camera
 
-<p class="header-link-container">
-  <a class="header-link" href="#get-bcf-camera-from-camera"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#get-bcf-camera-from-camera"></a></p>
 
 ```
 getBcfCamera();
@@ -480,9 +448,7 @@ Camera
 
 ### Navigation to the home viewpoint
 
-<p class="header-link-container">
-  <a class="header-link" href="#navigation-to-the-home-viewpoint"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#navigation-to-the-home-viewpoint"></a></p>
 
 ```
 navToHomeView();
@@ -510,9 +476,7 @@ Camera
 
 ### Set Euler Angles
 
-<p class="header-link-container">
-  <a class="header-link" href="#set-euler-angles"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#set-euler-angles"></a></p>
 
 ```
 setEulerAngles(x, y, z);
@@ -542,15 +506,11 @@ Camera
 
 ## DOM Namespace
 
-<p class="header-link-container">
-  <a class="header-link" href="#dom-namespace"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#dom-namespace"></a></p>
 
 ### Add Panel
 
-<p class="header-link-container">
-  <a class="header-link" href="#add-panel"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#add-panel"></a></p>
 
 ```
 addPanel(domElement);
@@ -580,9 +540,7 @@ Dom
 
 ### Remove Panel
 
-<p class="header-link-container">
-  <a class="header-link" href="#remove-panel"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#remove-panel"></a></p>
 
 ```
 removePanel(domElement);
@@ -610,9 +568,7 @@ Dom
 
 ## Events Namespace
 
-<p class="header-link-container">
-  <a class="header-link" href="#events-namespace"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#events-namespace"></a></p>
 
 Supported events are:
 
@@ -658,9 +614,7 @@ Supported events are:
 
 ### Add Event
 
-<p class="header-link-container">
-  <a class="header-link" href="#add-event"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#add-event"></a></p>
 
 ```
 addEventListener(eventName, callback);
@@ -691,9 +645,7 @@ Events
 
 ### Remove Event
 
-<p class="header-link-container">
-  <a class="header-link" href="#remove-event"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#remove-event"></a></p>
 
 ```
 removeEventListener(eventName, callback);
@@ -724,9 +676,7 @@ Events
 
 ### Dispatch Event
 
-<p class="header-link-container">
-  <a class="header-link" href="#dispatch-event"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#dispatch-event"></a></p>
 
 ```
 dispatchEvent(eventName, callback);
@@ -755,15 +705,11 @@ Events
 
 ## Model Namespace
 
-<p class="header-link-container">
-  <a class="header-link" href="#model-namespace"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#model-namespace"></a></p>
 
 ### Get Object from object id
 
-<p class="header-link-container">
-  <a class="header-link" href="#get-object-from-object-id"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#get-object-from-object-id"></a></p>
 
 ```
 getObject(objectId);
@@ -791,9 +737,7 @@ Model
 
 ### Get Hidden ID's
 
-<p class="header-link-container">
-  <a class="header-link" href="#get-hidden-ids"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#get-hidden-ids"></a></p>
 
 ```
 getHiddenGeoIds();
@@ -821,9 +765,7 @@ Model
 
 ### Add Hidden ID's
 
-<p class="header-link-container">
-  <a class="header-link" href="#add-hidden-ids"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#add-hidden-ids"></a></p>
 
 ```
 addHiddenGeoIds(objectIds);
@@ -854,9 +796,7 @@ Model
 
 ### Has Hidden ID's
 
-<p class="header-link-container">
-  <a class="header-link" href="#has-hidden-ids"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#has-hidden-ids"></a></p>
 
 ```
 hasHiddenGeoIds(objectIds);
@@ -888,9 +828,7 @@ Model
 
 ### Clear Hidden ID's
 
-<p class="header-link-container">
-  <a class="header-link" href="#clear-hidden-ids"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#clear-hidden-ids"></a></p>
 
 ```
 clearHiddenIds();
@@ -918,9 +856,7 @@ Model
 
 ### Get Selected ID's
 
-<p class="header-link-container">
-  <a class="header-link" href="#get-selected-ids"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#get-selected-ids"></a></p>
 
 ```
 getSelectedGeoIds();
@@ -948,9 +884,7 @@ Model
 
 ### Add Selected ID's
 
-<p class="header-link-container">
-  <a class="header-link" href="#add-selected-ids"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#add-selected-ids"></a></p>
 
 ```
 addSelectedIds(objectIds);
@@ -981,9 +915,7 @@ Model
 
 ### Has Selected ID's
 
-<p class="header-link-container">
-  <a class="header-link" href="#has-selected-ids"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#has-selected-ids"></a></p>
 
 ```
 hasSelectedIds(objectIds);
@@ -1015,9 +947,7 @@ Model
 
 ### Clear Selected ID's
 
-<p class="header-link-container">
-  <a class="header-link" href="#clear-selected-ids"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#clear-selected-ids"></a></p>
 
 ```
 clearSelectedIds();
@@ -1045,9 +975,7 @@ Model
 
 ### Set Object Color
 
-<p class="header-link-container">
-  <a class="header-link" href="#set-object-color"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#set-object-color"></a></p>
 
 ```
 setObjectColor(objectId, hexColor, opacity);
@@ -1079,9 +1007,7 @@ Model
 
 ### Get Sections
 
-<p class="header-link-container">
-  <a class="header-link" href="#get-sections"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#get-sections"></a></p>
 
 ```
 getSections();
@@ -1107,9 +1033,7 @@ Model
 
 ### Set Section Box
 
-<p class="header-link-container">
-  <a class="header-link" href="#set-section-box"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#set-section-box"></a></p>
 
 ```
 setSectionBox(minXYZ, maxXYZ, rotation);
@@ -1141,9 +1065,7 @@ Model
 
 ### Remove Section Box
 
-<p class="header-link-container">
-  <a class="header-link" href="#remove-section-box"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#remove-section-box"></a></p>
 
 ```
 removeSectionBox();
@@ -1171,9 +1093,7 @@ Model
 
 ### Add Section Plane
 
-<p class="header-link-container">
-  <a class="header-link" href="#add-section-plane"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#add-section-plane"></a></p>
 
 ```
 addSectionPlane(distance, normal);
@@ -1204,9 +1124,7 @@ Model
 
 ### Remove Section Plane
 
-<p class="header-link-container">
-  <a class="header-link" href="#remove-section-plane"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#remove-section-plane"></a></p>
 
 ```
 removeSectionPlane(uuid);
@@ -1236,9 +1154,7 @@ Model
 
 ### Clear Sections
 
-<p class="header-link-container">
-  <a class="header-link" href="#clear-sections"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#clear-sections"></a></p>
 
 ```
 clearSection();
@@ -1266,9 +1182,7 @@ Model
 
 ### Set Webviewer Configuration options
 
-<p class="header-link-container">
-  <a class="header-link" href="#set-webviewer-configuration-options"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#set-webviewer-configuration-options"></a></p>
 
 ```
 setOptions(options);
@@ -1300,9 +1214,7 @@ Model
 
 ### Get relative planmap space position based on model space position
 
-<p class="header-link-container">
-  <a class="header-link" href="#get-relative-planmap-space-position-based-on-model-space-position"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#get-relative-planmap-space-position-based-on-model-space-position"></a></p>
 
 ```
 MapToModelSpace(
@@ -1355,9 +1267,7 @@ Model
 
 ### Get relative model space position based on planmap space position
 
-<p class="header-link-container">
-  <a class="header-link" href="#get-relative-model-space-position-based-on-planmap-space-position"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#get-relative-model-space-position-based-on-planmap-space-position"></a></p>
 
 ```
 ModelToMapSpace(
@@ -1410,9 +1320,7 @@ Model
 
 ### Get Global Offset
 
-<p class="header-link-container">
-  <a class="header-link" href="#get-global-offset"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#get-global-offset"></a></p>
 
 ```
 getGlobalOffset();
@@ -1438,15 +1346,11 @@ Model
 
 ## Cache Namespace
 
-<p class="header-link-container">
-  <a class="header-link" href="#cache-namespace"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#cache-namespace"></a></p>
 
 ### Is the model cached
 
-<p class="header-link-container">
-  <a class="header-link" href="#is-the-model-cached"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#is-the-model-cached"></a></p>
 
 ```
 hasModel(urlsObject);
@@ -1485,9 +1389,7 @@ Promise(Boolean)
 
 ### Remove Model
 
-<p class="header-link-container">
-  <a class="header-link" href="#remove-model"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#remove-model"></a></p>
 
 ```
 removeModel(urlsObject);
@@ -1524,9 +1426,7 @@ Promise(boolean)
 
 ## Options
 
-<p class="header-link-container">
-  <a class="header-link" href="#options"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#options"></a></p>
 
 `version [number]` (required)
 
@@ -1760,15 +1660,11 @@ See [Tools](#tools) for further information.
 
 ## Objects
 
-<p class="header-link-container">
-  <a class="header-link" href="#objects"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#objects"></a></p>
 
 ### Perspective Camera Object
 
-<p class="header-link-container">
-  <a class="header-link" href="#perspective-camera-object"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#perspective-camera-object"></a></p>
 
 ```
 {
@@ -1784,9 +1680,7 @@ See [Tools](#tools) for further information.
 
 ### Orthogonal Camera Object
 
-<p class="header-link-container">
-  <a class="header-link" href="#orthogonal-camera-object"></a>
-</p>
+<p class="header-link-container"><a class="header-link" href="#orthogonal-camera-object"></a></p>
 
 ```
 {


### PR DESCRIPTION
## Description

This PR :
- adds the ability to add a link character next to `h2`, `h3`, and `h4` tags (`##`, `###`, and `####`) that links to that heading, which I'm dubbing as "Heading Links" for lack of a known name. This functionality is opt-in and available across all documentation pages
- adds info on how to use Heading Links to README
- adds these Heading Links to select headings in the BIM Webviewer API page.
- fixes a couple incorrect-seeming headers on the BIM Webviewer API page.

Basically the same feature exists on the Rest API side of things (e.g. https://developers.procore.com/reference/rest/v1/bim-file-extractions?version=1.0#show-bim-file-extraction), but I wasn't sure how to utilize that.


## Screenshots

https://user-images.githubusercontent.com/2865469/154759471-9560faf8-90ba-41a8-9285-a39879030309.mov

## How to Add a Heading Link to a Heading

Under the heading you'd like to link to you must add a snippet of inline html with an href that links to the heading. The heading ids appear to be auto-generated as the `kebab-case` version of the heading content

```md
### Get Camera Position

<p class="header-link-container"><a class="header-link" href="#get-camera-position"></a></p>
```

I found these docs for "GitLab Flavored Markdown" describing behavior of heading id generation: https://docs.gitlab.com/ee/user/markdown.html#header-ids-and-links. This probably isn't exactly what we're using but fits the bill.

You could also use a [custom heading id](https://www.markdownguide.org/extended-syntax#heading-ids) if the id generation is giving you trouble:

```md
### Get Camera Position {#my-custom-id}

<p class="header-link-container"><a class="header-link" href="#my-custom-id"></a></p>
```