### PR TITLE
[BIM] Add Loading Tool to BIM Webviewer Doc

### DIFF
--- a/other_procore_apis/bim_web_viewer.md
+++ b/other_procore_apis/bim_web_viewer.md
@@ -1760,14 +1760,15 @@ Otherwise, `rotation` will be undefined.
 | Tool             | Description                                                 |
 | ---------------- | ----------------------------------------------------------- |
 | BOTTOMTOOL       | Adds the bottom toolbar that will house other enabled tools |
-| FLOORPLAN        | Adds 2D Navigation minimap and modal                        |
-| MODELVIEWS       | Views Window                                                |
 | COACHMARKS       | All coachmarks                                              |
-| COACHMARKSHIDDEN | Hidden Objects coachmark label                              |
 | COACHMARKSECTION | Section Applied coachmark label                             |
-| MEASUREMENT_SD   | Shortest Distance tool                                      |
-| SETTINGS         | Settings Window to change unit display                      |
+| COACHMARKSHIDDEN | Hidden Objects coachmark label                              |
 | CONTEXTMENU      | Right click context menu                                    |
+| FLOORPLAN        | Adds 2D Navigation minimap and modal                        |
+| LOADING          | Adds loading screens for viewer initialization              |
+| MEASUREMENT_SD   | Shortest Distance tool                                      |
+| MODELVIEWS       | Views Window                                                |
+| SETTINGS         | Settings Window to change unit display                      |
 | VIEW_PROPERTIES  | View properties of an object                                |
 
 `MEASUREMENT_SD`


### PR DESCRIPTION
# DO NOT MERGE UNTIL 4/20

## Description

https://github.com/procore/bim-webviewer/pull/540 adds a LOADING tool to [@procore/bim-webviewer-sdk](https://www.npmjs.com/package/@procore/bim-webviewer-sdk). 

This PR updates the docs to reflect that. It should go out on April 20 when we publish those changes.

It also alphabetizes the tools list. Previously it didn't seem like there was any particular order to them.

## Screenshots

![image](https://user-images.githubusercontent.com/2865469/162289214-fa4fe5b3-4e90-407a-bf08-335d67164453.png)
