### PR TITLE
[BIM] Add `camera.zoomExtents(bbox)` to BIM Webviewer Doc

### DIFF
--- a/other_procore_apis/bim_web_viewer.md
+++ b/other_procore_apis/bim_web_viewer.md
@@ -441,6 +441,36 @@ Camera
 
 ---
 
+### Zoom to Extents of a Bounding Box
+
+<p class="heading-link-container"><a class="heading-link" href="#zoom-to-extents-of-a-bounding-box"></a></p>
+
+```js
+zoomExtents(bbox);
+```
+
+#### Description
+
+Moves camera such that the specified axis-aligned bounding box is in view.
+
+#### Parameters
+
+| Field Name | Required | Type | Description |
+| - | - | - | - |
+| bbox | true | BoundingBox | `{ min: { x: Number, y: Number, z: Number }, max: { x: Number, y: Number, z: Number } }` |
+
+##### Returns
+
+```js
+undefined
+```
+
+##### Namespace
+
+Camera
+
+---
+
 ### Set Euler Angles
 
 <p class="heading-link-container"><a class="heading-link" href="#set-euler-angles"></a></p>


### PR DESCRIPTION
# DO NOT MERGE UNTIL 5/19

## Description

https://github.com/procore/bim-webviewer/pull/570 adds `camera.zoomExtents(bbox)` to [@procore/bim-webviewer-sdk](https://www.npmjs.com/package/@procore/bim-webviewer-sdk). 

This PR updates the docs to reflect that. It should go out on May 19 when we publish those changes.

## Screenshots

![image](https://user-images.githubusercontent.com/2865469/168911074-cc059820-115d-4b07-9cb8-b2decba37db3.png)
