### PR TITLE
[BIM] Update BIM Webviewer Docs on Installation

### DIFF
--- a/other_procore_apis/bim_web_viewer.md
+++ b/other_procore_apis/bim_web_viewer.md
@@ -11,13 +11,57 @@ section_title: Other Procore APIs
 
 <p class="heading-link-container"><a class="heading-link" href="#getting-started"></a></p>
 
-The Procore BIM Web Viewer is a single distributable Javascript file.
+### Installation
 
-Instantiate the viewer with the options argument, and start rendering when ready.
+<p class="heading-link-container"><a class="heading-link" href="#installation"></a></p>
 
-- Add `<script type='text/javascript' src='dist/Procore.Bim.Webviewer.js'></script>` to your page
-- Instantiate a new viewer with options: `const viewer = new ProcoreBim.Webviewer(options);`
-- Start the viewer: `viewer.start();`
+The Procore BIM Web Viewer is available as a module on `npm` as [`@procore/bim-webviewer-sdk`](https://www.npmjs.com/package/@procore/bim-webviewer-sdk).
+
+To install it, open a terminal window in your project folder and run:
+
+```sh
+npm install @procore/bim-webviewer-sdk
+```
+
+---
+
+Though not recommended for production use, if you just want to prototype something you can use a tool like [`unpkg`](https://unpkg.com/) to get the module onto a page without the overhead of a build-system.
+
+```html
+<script src="https://unpkg.com/@procore/bim-webviewer-sdk"></script>
+```
+
+### Usage
+
+<p class="heading-link-container"><a class="heading-link" href="#usage"></a></p>
+
+### Load the Module
+
+<p class="heading-link-container"><a class="heading-link" href="#load-the-module"></a></p>
+
+Get the script on your page somehow!
+
+If you're using a bundling system with `import` (recommended):
+
+```js
+import * as ProcoreBim from '@procore/bim-webviewer-sdk';
+```
+
+Or more manually:
+
+```html
+<!-- This will instantiate window.ProcoreBim -->
+<script src='dist/Procore.Bim.Webviewer.js'></script>
+```
+
+### Instantiate and Start the Viewer
+
+<p class="heading-link-container"><a class="heading-link" href="#instantiate-and-start-the-viewer"></a></p>
+
+```js
+const viewer = new ProcoreBim.Webviewer(options);
+viewer.start();
+```
 
 See the [Options](#options) section for more detail on the options object.
 

--- a/other_procore_apis/bim_web_viewer.md
+++ b/other_procore_apis/bim_web_viewer.md
@@ -31,10 +31,6 @@ Though not recommended for production use, if you just want to prototype somethi
 <script src="https://unpkg.com/@procore/bim-webviewer-sdk"></script>
 ```
 
-### Usage
-
-<p class="heading-link-container"><a class="heading-link" href="#usage"></a></p>
-
 ### Load the Module
 
 <p class="heading-link-container"><a class="heading-link" href="#load-the-module"></a></p>

--- a/other_procore_apis/bim_web_viewer.md
+++ b/other_procore_apis/bim_web_viewer.md
@@ -11,9 +11,9 @@ section_title: Other Procore APIs
 
 <p class="heading-link-container"><a class="heading-link" href="#getting-started"></a></p>
 
-### Installation
+### Installation from NPM (recommended)
 
-<p class="heading-link-container"><a class="heading-link" href="#installation"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#installation-from-npm-recommended"></a></p>
 
 The Procore BIM Web Viewer is available as a module on `npm` as [`@procore/bim-webviewer-sdk`](https://www.npmjs.com/package/@procore/bim-webviewer-sdk).
 
@@ -23,19 +23,27 @@ To install it, open a terminal window in your project folder and run:
 npm install @procore/bim-webviewer-sdk
 ```
 
----
+### Installation from a CDN
 
-Though not recommended for production use, if you just want to prototype something you can use a tool like [`unpkg`](https://unpkg.com/) to get the module onto a page without the overhead of a build-system.
+<p class="heading-link-container"><a class="heading-link" href="#installation-from-a-cdn"></a></p>
+
+Though not recommended for production use, if you just want to prototype something you can use a tool like [`unpkg`](https://unpkg.com/) to get the module onto a page without the overhead of a build-system. Note we do not control `unpkg` and do not otherwise host the package on a publicly available CDN with uptime guarantees.
 
 ```html
 <script src="https://unpkg.com/@procore/bim-webviewer-sdk"></script>
 ```
 
-### Load the Module
+### Installation by Saving the File
 
-<p class="heading-link-container"><a class="heading-link" href="#load-the-module"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#installation-by-saving-the-file"></a></p>
 
-Get the script on your page somehow!
+If you prefer not to use `npm`, you can download the latest version of the code here: [https://unpkg.com/@procore/bim-webviewer-sdk](https://unpkg.com/@procore/bim-webviewer-sdk)
+
+If you would like a specific version you can declare that version in the url like so: [https://unpkg.com/@procore/bim-webviewer-sdk@4.0.0](https://unpkg.com/@procore/bim-webviewer-sdk@4.0.0)
+
+### Load the Module with a Bundler (recommended)
+
+<p class="heading-link-container"><a class="heading-link" href="#load-the-module-with-a-bundler-recommended"></a></p>
 
 If you're using a bundling system with `import` (recommended):
 
@@ -43,11 +51,15 @@ If you're using a bundling system with `import` (recommended):
 import * as ProcoreBim from '@procore/bim-webviewer-sdk';
 ```
 
-Or more manually:
+### Load the Module Manually
+
+<p class="heading-link-container"><a class="heading-link" href="#load-the-module-manually"></a></p>
+
+If you're managing script loading manually:
 
 ```html
 <!-- This will instantiate window.ProcoreBim -->
-<script src='dist/Procore.Bim.Webviewer.js'></script>
+<script src='path/to/Procore.Bim.Webviewer.js'></script>
 ```
 
 ### Instantiate and Start the Viewer


### PR DESCRIPTION
We got a [comment from a dev at a third-party partner Inertia](https://procore-external.slack.com/archives/C01T2SGTEKB/p1658943944795329) about installation and reminded me that our installation docs are a little outdated so this updates them.

![image](https://user-images.githubusercontent.com/2865469/181653321-5634cb79-7b96-49a7-917f-0a5ecc9f8446.png)