### PR TITLE
DOCS-520 updating content related to Implicit Grant

### DIFF
--- a/other_procore_apis/bim_web_viewer.md
+++ b/other_procore_apis/bim_web_viewer.md
@@ -2067,11 +2067,13 @@ Promise(boolean)
 
 OAuth access token used to authenticate requests to the Procore API made by the Web Viewer SDK on your behalf (e.g. fetching an object's properties). Specifically it adds an `Authorization` header with the provided token to each request. See [Making Your First API Call](/documentation/making-first-call) for details on retrieving an access token.
 
-Note also that this setup implies an Implicit Grant flow in that your access token will be present on the browser rather than only present on a server, which may be a security concern. See [OAuth 2.0 Implicit Grant](/documentation/oauth-implicit-flow) for details on Implicit Grant flow.
+Note also that this setup implies an Implicit Grant flow in that your access token will be present on the browser rather than only present on a server, which may be a security concern. See section 2.1.2 of [IETF OAuth 2.0 Security Best Current Practice](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics-20#page-7) for information on the risk posed by using the Implicit Grant flow.
 
-If this is not provided as an option, you will need to intercept the SDK's requests and attach the `Authorization` header yourself in order for them to succeed.
+If the access token is not provided as an option, you will need to intercept the SDK's requests and attach the `Authorization` header yourself in order for them to succeed.
 
 Additionally, the access token will eventually expire (in 24 hours currently for an implicitly granted token) and requests made by the SDK will fail. We don't yet have a way to notify of these errors and refresh the in-use access token. One workaround is to keep track of the expiration time for the access token (provided in the `expires_in` query param in the Implicit Grant flow) and re-instantiate the `ProcoreBim.Webviewer` with the new access token.
+
+If you want to avoid using the Implicit Grant flow you could set up a server at say `https://auth-proxy.myapp.com` and pass that in as the `baseUrl`. All SDK requests will then be made to your server which could add the `Authorization` header and make the actual request to the Procore API.
 
 `baseUrl [string]`
 
@@ -2084,8 +2086,6 @@ Additionally, the access token will eventually expire (in 24 hours currently for
 The `baseUrl` is a mechanism for determining which version of the Procore API you will hit.
 
 For example, while developing a third-party Procore App, you may want to utilize one of the [Sandbox Environments](https://developers.procore.com/documentation/development-environments). To use the Development Sandbox, you could pass `baseUrl: 'https://sandbox.procore.com/'` and any requests made by the SDK will be made to that origin.
-
-Another example is if you want to avoid using the Implicit Grant flow you might set up a server at say `https://auth-proxy.myapp.com` and pass that in as the `baseUrl`. All SDK requests will then be made to your server which could add the `Authorization` header and make the actual request to the Procore API.
 
 `parentElement [Element]` (required)
 


### PR DESCRIPTION
Updated section on request options with respect to the implicit grant type. API Support has indicated that they no longer support the Implicit Grant type due to security concerns and all relevant documentation has been removed. That said, the Implicit flow will still work with the Procore API, but its use is highly discouraged. Replaced the link to our (now removed) implicit oauth page with a link to the IETF Current Best Practice article.
@sbieserprocore @Bates550 