### PR TITLE
 [BIM-Webviewer] Fix Links for Zoom Extents Methods

### DIFF
--- a/other_procore_apis/bim_web_viewer.md
+++ b/other_procore_apis/bim_web_viewer.md
@@ -497,7 +497,7 @@ Camera
 
 ### Zoom to Objects
 
-<p class="heading-link-container"><a class="heading-link" href="zoom-to-objects"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#zoom-to-objects"></a></p>
 
 ```js
 zoomToObjects(objectIds);
@@ -527,7 +527,7 @@ Camera
 
 ### Zoom to Fit a Bounding Box
 
-<p class="heading-link-container"><a class="heading-link" href="zoom-to-fit-a-bounding-box"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#zoom-to-fit-a-bounding-box"></a></p>
 
 ```js
 zoomToBoundingBox(bbox);
@@ -557,7 +557,7 @@ Camera
 
 ### Zoom to Selection
 
-<p class="heading-link-container"><a class="heading-link" href="zoom-to-selection"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#zoom-to-selection"></a></p>
 
 ```js
 zoomToSelection();
@@ -585,7 +585,7 @@ Camera
 
 ### Zoom to Global
 
-<p class="heading-link-container"><a class="heading-link" href="zoom-to-global"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#zoom-to-global"></a></p>
 
 ```js
 zoomToGlobal();


### PR DESCRIPTION
The link button was pointing to the wrong url and lead to a 404. This PR fixes that.

![image](https://user-images.githubusercontent.com/2865469/196336976-cff6cef8-eb0c-4493-92d4-f7dc4b77ee0f.png)
