### PR TITLE
[BIM-2511] Added `model.getObjects` documentation

### DIFF
--- a/bim_webviewer/bim_web_viewer.md
+++ b/bim_webviewer/bim_web_viewer.md
@@ -2016,7 +2016,7 @@ getObject(id);
 
 #### Description
 
-Returns a JavaScript object that describes the model object defined by the id. Contains data such as bounding box, hidden/selected states, and parent/child relationships.
+Returns a model object with the given id. Contains data such as bounding box, hidden/selected states, and parent/child relationships.
 
 #### Parameters
 
@@ -2058,7 +2058,7 @@ getObjects(objectIds);
 
 #### Description
 
-Returns an array of JavaScript objects where each JavaScript object describes the model object as defined by each id in the array. Contains data such as bounding box, hidden/selected states, and parent/child relationships.
+Returns an array of model objects as defined by each id in the array. Contains data such as bounding box, hidden/selected states, and parent/child relationships.
 
 #### Parameters
 

--- a/bim_webviewer/bim_web_viewer.md
+++ b/bim_webviewer/bim_web_viewer.md
@@ -2016,7 +2016,7 @@ getObject(id);
 
 #### Description
 
-Returns a JavaScript object that describes the object defined by the id. Contains data such as bounding box, hidden/selected states, and parent/child relationships.
+Returns a JavaScript object that describes the model object defined by the id. Contains data such as bounding box, hidden/selected states, and parent/child relationships.
 
 #### Parameters
 
@@ -2040,6 +2040,50 @@ Returns a JavaScript object that describes the object defined by the id. Contain
   parentId: number,
   children: number[]
 }
+```
+
+##### Namespace
+
+Model
+
+---
+
+### Get Objects
+
+<p class="heading-link-container"><a class="heading-link" href="#get-objects"></a></p>
+
+```js
+getObjects(objectIds);
+```
+
+#### Description
+
+Returns an array of JavaScript objects where each JavaScript object describes the model object as defined by each id in the array. Contains data such as bounding box, hidden/selected states, and parent/child relationships.
+
+#### Parameters
+
+| Field Name | Required | Type | Description |
+| - | - | - | - |
+| objectIds | true | number[] | An array of object ids. |
+
+##### Returns
+
+```js
+[
+  {
+    id: number, 
+    bbox: {
+      min: number[],
+      max: number[]
+    }, 
+    nodeType: number,
+    hidden: boolean,
+    selected: boolean,
+    partiallySelected: boolean,
+    parentId: number,
+    children: number[]
+  }
+]
 ```
 
 ##### Namespace

--- a/bim_webviewer/bim_web_viewer.md
+++ b/bim_webviewer/bim_web_viewer.md
@@ -2081,6 +2081,51 @@ Model
 
 ---
 
+
+### Get Objects
+
+<p class="heading-link-container"><a class="heading-link" href="#get-objects"></a></p>
+
+```js
+getObjects(objectIds);
+```
+
+#### Description
+
+Returns an array of model objects as defined by each id in the array. Contains data such as bounding box, hidden/selected states, and parent/child relationships.
+
+#### Parameters
+
+| Field Name | Required | Type | Description |
+| - | - | - | - |
+| objectIds | true | number[] | An array of object ids. |
+
+##### Returns
+
+```js
+[
+  {
+    id: number, 
+    bbox: {
+      min: number[],
+      max: number[]
+    }, 
+    nodeType: number,
+    hidden: boolean,
+    selected: boolean,
+    partiallySelected: boolean,
+    parentId: number,
+    children: number[]
+  }
+]
+```
+
+##### Namespace
+
+Model
+
+---
+
 ### Get Root Object
 
 <p class="heading-link-container"><a class="heading-link" href="#get-root-object"></a></p>


### PR DESCRIPTION
# DO NOT MERGE UNTIL: 3/3/2023

Added `getObjects` documentation to our `model` namespace.

![image](https://user-images.githubusercontent.com/43766070/220744658-3c27545d-8acb-471b-82d5-4da48514e403.png)
