### PR TITLE
[BIM-2430] Added `windowOpen` and `windowClose` events to documentation

### DIFF
--- a/bim_webviewer/bim_web_viewer.md
+++ b/bim_webviewer/bim_web_viewer.md
@@ -1371,9 +1371,9 @@ Fires when a window based tool has changed its position or size.
 
 ---
 
-### onWindowOpen
+### windowOpen
 
-<p class="heading-link-container"><a class="heading-link" href="#onwindowopen"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#windowopen"></a></p>
 
 Fires when a window based tool has been opened.
 
@@ -1387,9 +1387,9 @@ Fires when a window based tool has been opened.
 
 ---
 
-### onWindowHide
+### windowClose
 
-<p class="heading-link-container"><a class="heading-link" href="#onwindowhide"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#windowclose"></a></p>
 
 Fires when a window based tool has been hidden.
 

--- a/bim_webviewer/bim_web_viewer.md
+++ b/bim_webviewer/bim_web_viewer.md
@@ -1369,6 +1369,38 @@ Fires when a window based tool has changed its position or size.
 | modalSize  | object | An object with the keys, `height`, `left`, `top`, `width` to indicate the current position and size of the window. |
 | name       | string | Human readable name of the window based tool that is changing.                                                     |
 
+---
+
+### onWindowOpen
+
+<p class="heading-link-container"><a class="heading-link" href="#onwindowopen"></a></p>
+
+Fires when a window based tool has been opened.
+
+#### Data Properties
+
+| Field Name | Type | Description |
+| - | - | - |
+| id | string | The name of the window based tool that has been opened. |
+| name | string | Human readable name of the window based tool that has been opened. |
+| element | DOM | The DOM Node of the window based tool. |
+
+---
+
+### onWindowHide
+
+<p class="heading-link-container"><a class="heading-link" href="#onwindowhide"></a></p>
+
+Fires when a window based tool has been hidden.
+
+#### Data Properties
+
+| Field Name | Type | Description |
+| - | - | - |
+| id | string | The name of the window based tool that has been hidden. |
+| name | string | Human readable name of the window based tool that has been hidden. |
+| element | DOM | The DOM Node of the window based tool. |
+
 ## Model Namespace
 
 <p class="heading-link-container"><a class="heading-link" href="#model-namespace"></a></p>

--- a/bim_webviewer/bim_web_viewer.md
+++ b/bim_webviewer/bim_web_viewer.md
@@ -1381,9 +1381,9 @@ Fires when a window based tool has been opened.
 
 | Field Name | Type | Description |
 | - | - | - |
-| id | string | The name of the window based tool that has been opened. |
-| name | string | Human readable name of the window based tool that has been opened. |
-| element | DOM | The DOM Node of the window based tool. |
+| elementId | string | The value of the id attribute on the root DOM element of the window. |
+| toolId | number | The id of the tool the window belongs to. See [Tools](#tools) for further information. |
+
 
 ---
 
@@ -1397,9 +1397,8 @@ Fires when a window based tool has been hidden.
 
 | Field Name | Type | Description |
 | - | - | - |
-| id | string | The name of the window based tool that has been hidden. |
-| name | string | Human readable name of the window based tool that has been hidden. |
-| element | DOM | The DOM Node of the window based tool. |
+| elementId | string | The value of the id attribute on the root DOM element of the window. |
+| toolId | number | The id of the tool the window belongs to. See [Tools](#tools) for further information. |
 
 ## Model Namespace
 
@@ -3003,7 +3002,8 @@ Otherwise, `rotation` will be undefined.
 | MEASUREMENT_SD   | Shortest Distance tool                                      |
 | MODELVIEWS       | Views Window                                                |
 | SETTINGS         | Settings Window to change unit display                      |
-| VIEW_PROPERTIES  | View properties of an object                                |
+| VIEW_PROPERTIES  | Properties Window to display properties of an object        |
+| OBJECTMODELTREE  | Object Tree Window                                          |
 
 `MEASUREMENT_SD`
 


### PR DESCRIPTION
# DO NOT MERGE UNTIL 3/31

Added new events `windowOpen` and `windowClose` to our `events` namespace.
![image](https://user-images.githubusercontent.com/43766070/225452878-4d79bcde-a7f1-4cd4-8f19-1af0bce8301e.png)

