### PR TITLE
[BIM-2581] Animate payload event documentation

### DIFF
--- a/bim_webviewer/bim_web_viewer.md
+++ b/bim_webviewer/bim_web_viewer.md
@@ -867,6 +867,20 @@ viewer.events.addEventListener('bcfCameraSet', () => {
 viewer.start();
 ```
 
+### animate
+
+<p class="heading-link-container"><a class="heading-link" href="#animate"></a></p>
+
+Fires at the end of the animation loop. Returns an object containing the property `stage` to indicate the stage the renderer is in to render the scene. `renderIdle` indicates that the scene has been fully rendered and the renderer is no longer rendering any objects. `renderStart` indicates the start of rendering a scene. `renderProgress` is a state after `renderStart` and indicates the renderer is still rendering the scene. Finally, `renderComplete` indicates that all the objects have been rendered.
+
+#### Data Properties
+
+| Field Name | Type | Description |
+| - | - | - |
+| stage | string | The stage the renderer is in during the animation loop. Can either be `renderIdle`, `renderStart`, `renderProgress`, or `renderComplete`. |
+
+---
+
 ### appResize
 
 <p class="heading-link-container"><a class="heading-link" href="#appresize"></a></p>


### PR DESCRIPTION
# DO NOT MERGE UNTIL 3/31

Added new event `animate` which was previously not documented, as well as documented the payload it will have.
![image](https://user-images.githubusercontent.com/43766070/226420022-803bfbed-adf4-4588-9486-fce730b9cded.png)
