### PR TITLE
Docs 733 adding webrick to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,5 @@ group :jekyll_plugins do
 end
 
 gem "minima", "~> 2.5"
+
+gem "webrick", "~> 1.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,6 +255,7 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (1.8.0)
+    webrick (1.8.1)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -266,6 +267,7 @@ DEPENDENCIES
   github-pages (~> 214)
   jekyll-feed (~> 0.12)
   minima (~> 2.5)
+  webrick (~> 1.8)
 
 BUNDLED WITH
    2.1.4

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -69,7 +69,7 @@
       url: /building-apps-review-manifest
     - title: Creating a Marketplace Listing and Submitting for Review
       url: /building-apps-submit-marketplace
-    - title: Building Side Panel Applications
+    - title: Building Procore Side Panel Applications
       url: /building-side-panel-apps
     - title: Managing App Collaboration
       url: /building-apps-manage-collabs

--- a/building_applications/building_side_panel_apps.md
+++ b/building_applications/building_side_panel_apps.md
@@ -1,6 +1,6 @@
 ---
 permalink: /building-side-panel-apps
-title: Building Side Panel Applications
+title: Building Procore Side Panel Applications
 layout: default
 section_title: Building Applications
 ---


### PR DESCRIPTION
Adding webrick gem to the gemfile as it apparently is no longer automatically included as a jekyll dependency.