### PR TITLE
DOCS-738 Update postMessage method example code

### DIFF
--- a/building_applications/building_side_panel_apps.md
+++ b/building_applications/building_side_panel_apps.md
@@ -144,6 +144,11 @@ window.addEventListener('message', (event) => {
 window.parent.postMessage({ type: 'initialize' }, 'https://example.com/my-side-panel-app');
 ```
 
+In the example above we have set the value for the `targetOrigin` parameter of the `postMessage` method to `https://example.com/my-side-panel-app`.
+The `targetOrigin` parameter in this method specifies the origin of the window that should receive the message.
+It is important that you always provide a specific, fully-qualified URI in the `targetOrigin` parameter to ensure the best security.
+For more information, see the [postMessage() method documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage).
+
 ## Additional postMessage Events
 
 Aside from the “setup” message event that is fired when your app is first started, there are additional events fired at different life cycles of the side panel app. 

--- a/building_applications/building_side_panel_apps.md
+++ b/building_applications/building_side_panel_apps.md
@@ -141,7 +141,7 @@ window.addEventListener('message', (event) => {
     const resource_id = obj.context.id;
   }});
 
-window.parent.postMessage({ type: 'initialize' }, '*');
+window.parent.postMessage({ type: 'initialize' }, 'https://example.com/my-side-panel-app');
 ```
 
 ## Additional postMessage Events

--- a/building_applications/building_side_panel_apps.md
+++ b/building_applications/building_side_panel_apps.md
@@ -147,7 +147,7 @@ window.parent.postMessage({ type: 'initialize' }, 'https://example.com/my-side-p
 In the example above we have set the value for the `targetOrigin` parameter of the `postMessage` method to `https://example.com/my-side-panel-app`.
 The `targetOrigin` parameter in this method specifies the origin of the window that should receive the message.
 It is important that you always provide a specific, fully-qualified URI in the `targetOrigin` parameter to ensure the best security.
-For more information, see the [postMessage() method documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage).
+For additional information, see the [postMessage() method documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage).
 
 ## Additional postMessage Events
 


### PR DESCRIPTION
Updating the postMessage example code to be more explicit with the `targetOrigin` parameter, reducing the chance for security problems caused from a dev cutting/pasting the sample code verbatim into their project.