### PR TITLE
[BIM-3366] Document Section Box Display Methods and Events

### DIFF
--- a/bim_webviewer/bim_web_viewer.md
+++ b/bim_webviewer/bim_web_viewer.md
@@ -1467,6 +1467,37 @@ Fires when a single click occurs in the webviewer container element. This event 
 
 ---
 
+### sectionBoxDisplayConfigured
+
+<p class="heading-link-container"><a class="heading-link" href="#sectionboxdisplayconfigured"></a></p>
+
+Fires when the section box display is configured (e.g. via [`model.configureSectionBoxDisplay`](#configure-section-box-display)).
+
+#### Data Properties
+
+| Field Name | Type | Description |
+| - | - | - |
+| current | SectionBoxDisplayConfiguration | The configuration that has now taken effect. See [`model.configureSectionBoxDisplay`](#configure-section-box-display)'s params for shape of configuration. |
+| previous | SectionBoxDisplayConfiguration | The configuration before the change that fired this event. See [`model.configureSectionBoxDisplay`](#configure-section-box-display)'s params for shape of configuration. |
+| enabled | boolean | Whether the section box display is enabled or not |
+
+---
+
+### sectionBoxDisplayToggled
+
+<p class="heading-link-container"><a class="heading-link" href="#sectionboxdisplaytoggled"></a></p>
+
+Fires when the section box display is toggled on or off (e.g. via [`model.toggleSectionBoxDisplay`](#toggle-section-box-display)).
+
+#### Data Properties
+
+| Field Name | Type | Description |
+| - | - | - |
+| configuration | SectionBoxDisplayConfiguration | The configuration that was used when the section box display was toggled on. See [`model.configureSectionBoxDisplay`](#configure-section-box-display)'s params for shape of configuration. |
+| value | boolean | Whether the section box display was enabled or disabled |
+
+---
+
 ### sectionBoxSet
 
 <p class="heading-link-container"><a class="heading-link" href="#sectionboxset"></a></p>

--- a/bim_webviewer/bim_web_viewer.md
+++ b/bim_webviewer/bim_web_viewer.md
@@ -2094,6 +2094,81 @@ Model
 
 ---
 
+### Toggle Section Box Display
+
+<p class="heading-link-container"><a class="heading-link" href="#toggle-section-box-display"></a></p>
+
+```js
+toggleSectionBoxDisplay(enable);
+```
+
+#### Description
+
+Sets the on/off status of the section box display.
+
+The section box display is the UI widget that allows users to interactively set the section box.
+
+When turned on it will take the size of the existing section box that is clipping the model (e.g. from a call to [`model.setSectionBox`](#set-section-box)). If there is no section box set it will error. If the section box is set while the display is toggled on, the display will also change size to match the section box.
+
+The section box display can be configured through the [`model.configureSectionBoxDisplay`](#configure-section-box-display) method.
+
+#### Parameters
+
+| Field Name | Required | Type    | Description                                     |
+| ---------- | -------- | ------- | ----------------------------------------------- |
+| enable     | true     | boolean | on/off status to set the section box display to |
+
+##### Returns
+
+```js
+undefined
+```
+
+##### Namespace
+
+Model
+
+---
+
+### Configure Section Box Display
+
+<p class="heading-link-container"><a class="heading-link" href="#configure-section-box-display"></a></p>
+
+```js
+configureSectionBoxDisplay(config);
+```
+
+#### Description
+
+Configures how the section box display (controlled by [`model.toggleSectionBoxDisplay`](#toggle-section-box-display)) will appear.
+
+When the section box display is enabled, calling `configureSectionBoxDisplay` will take effect immediately. When the section box display is not enabled, the configuration changes will apply the next time the section box display is enabled.
+
+#### Parameters
+
+| Field Name | Required | Type    | Description                                     |
+| ---------- | -------- | ------- | ----------------------------------------------- |
+| config     | false    | Object  | Configuration object to change the behavior of the section box display. If called with no config argument, it will revert to the default config. |
+
+##### config
+
+| Field Name | Required | Type    | Description                                     |
+| ---------- | -------- | ------- | ----------------------------------------------- |
+| dropdown   | false    | boolean | Determines whether the section tool dropdown appears. Defaults to true. |
+| hidePlanes | false    | boolean | Determines whether the planes of the section box display are shown. When they are hidden, the arrows still show. Defaults to false. |
+
+##### Returns
+
+```js
+undefined
+```
+
+##### Namespace
+
+Model
+
+---
+
 ### Add Section Plane
 
 <p class="heading-link-container"><a class="heading-link" href="#add-section-plane"></a></p>

--- a/bim_webviewer/bim_web_viewer.md
+++ b/bim_webviewer/bim_web_viewer.md
@@ -1195,6 +1195,18 @@ Fires when the camera field of view has been changed. Returns a number in degree
 
 ---
 
+### globalBoundingBoxInitialized
+
+<p class="heading-link-container"><a class="heading-link" href="#globalboundingboxinitialized"></a></p>
+
+Fires when the global bounding box of the model has been determined.
+
+#### Data Properties
+
+| Field Name | Type | Description |
+| - | - | - |
+| bbox | BoundingBox | `{ min: { x: Number, y: Number, z: Number }, max: { x: Number, y: Number, z: Number } }` |
+
 ### hideUpdated
 
 <p class="heading-link-container"><a class="heading-link" href="#hideupdated"></a></p>

--- a/bim_webviewer/bim_web_viewer.md
+++ b/bim_webviewer/bim_web_viewer.md
@@ -2039,7 +2039,7 @@ Model
 <p class="heading-link-container"><a class="heading-link" href="#set-section-box"></a></p>
 
 ```js
-setSectionBox(minXYZ, maxXYZ, rotation);
+setSectionBox(minXYZ, maxXYZ, rotation, showCoachmark);
 ```
 
 #### Description
@@ -2048,11 +2048,12 @@ Sets section box given an XYZ max and min and rotation(optional);
 
 #### Parameters
 
-| Field Name | Required | Type   | Description                         |
-| ---------- | -------- | ------ | ----------------------------------- |
-| minXYZ     | true     | Object | { x: Number, y: Number, z: Number } |
-| maxXYZ     | true     | Object | { x: Number, y: Number, z: Number } |
-| rotation   | false    | Object | { x: Number, y: Number, z: Number } |
+| Field Name    | Required | Type    | Description                         |
+| ------------- | -------- | ------- | ----------------------------------- |
+| minXYZ        | true     | Object  | { x: Number, y: Number, z: Number } |
+| maxXYZ        | true     | Object  | { x: Number, y: Number, z: Number } |
+| rotation      | false    | Object  | { x: Number, y: Number, z: Number } |
+| showCoachmark | false    | boolean | Determines whether the Sectioning Applied coachmark is shown. Defaults to true. |
 
 ##### Returns
 


### PR DESCRIPTION
Documents the updates that occurred in v9.1.0: 

```md
- Add new SDK methods and events to control the section box display
  - new method: `model.configureSectionBoxDisplay` - sets state for how the section box display will appear
  - new method: `model.toggleSectionBoxDisplay` - turns on/off the section box display feature, respecting the configuration set by `configureSectionBoxDisplay`
  - changed method: `model.setSectionBox` - now takes a fourth argument `showCoachmark` which is a boolean that determines whether the "Sectioning Applied" coachmark is shown when the section box is set. Defaults to true, which was was the behavior before when it was not exposed as an argument.
    - Full signature now looks like: `model.setSectionBox(min: Vector3, max: Vector3, rotation: Vector3, showCoachmark?: boolean)`
    - Where `Vector3 = { x: number, y: number, z: number }`
  - new event: `sectionBoxDisplayConfigured` - fired when the section box display configuration changes
  - new event: `sectionBoxDisplayToggled` - fired when the section box display is toggled
  - new event: `globalBoundingBoxInitialized` - fired when the global bounding box of the model has been determined. This is used to implement the Sectioning dropdown's Reset Planes button.
  - new payload for event: `sectionBoxSet` - now includes the box that was set in its payload.
```
https://github.com/procore/bim-webviewer/blob/c40d8c99155049022d0860b8c67846c119d44d8f/package/CHANGELOG.md#L12-L21