### PR TITLE
[BIM-3729] Document all modes supported by `setNavigationMode`

### DIFF
--- a/bim_webviewer/bim_web_viewer.md
+++ b/bim_webviewer/bim_web_viewer.md
@@ -3114,14 +3114,23 @@ setNavigationMode(mode);
 
 #### Description
 
-Sets the navigation mode. The following values for `mode` are: 0 for the default mode, 1 for fly, and 2 for orbit. 
+Sets the navigation mode. The navigation mode determines how the camera responds to mouse, keyboard, and wheel events.
 
+| `mode` Value | Description |
+| - | - |
+| 0 | Default |
+| 1 | Fly |
+| 2 | Orbit |
+| 3 | Measure |
+| 4 | Strafe |
+| 5 | Pan |
+| 6 | Survey |
 
 #### Parameters
 
 | Field Name | Required | Type | Description |
 | - | - | - | - |
-| mode | true | number | The following values for `mode` are: 0 for the default mode, 1 for fly, and 2 for orbit. |
+| mode | true | number | See above description |
 
 ##### Returns
 


### PR DESCRIPTION
## Do Not Merge Until 2/7

Mainly updating this to document these changes that add a new "survey" mode https://github.com/procore/bim-webviewer/pull/1119, but also reworded the current documentation to show all the supported modes.
