### PR TITLE
[BIM-3495] Add migration guide for methods/events that return `bbox` in world coordinates

### DIFF
--- a/bim_webviewer/bim_web_viewer.md
+++ b/bim_webviewer/bim_web_viewer.md
@@ -3873,6 +3873,25 @@ The one addition we've made is the `unit` field. If the `unit` is not present, w
   <a class="heading-link" href="#migration-guides"></a>
 </p>
 
+### v11 to v12
+
+<p class="heading-link-container">
+  <a class="heading-link" href="#v11-to-v12"></a>
+</p>
+
+#### Continuation of consistent world coordinates
+
+These methods now return model objects with `bbox` properties in world coordinates:
+- `model.getObject`
+- `model.getObjects`
+- `model.getRootObject`
+
+These events now return payloads with model objects with `bbox` properties in world coordinates:
+- `objectSingleClick`
+- `objectSelect`
+
+If you were using these methods or events, you will need to update your code to be in the appropriate coordinate system. See [Migrating to World Coordinates](#migrating-to-world-coordinates)
+
 ### v10 to v11
 
 <p class="heading-link-container">


### PR DESCRIPTION
![image](https://github.com/procore/documentation/assets/43766070/7bff7fb2-3bb8-411b-b0be-0b9504e2aaa6)
