### PR TITLE
[BIM-3878] Document `resetSectionBox`, `getNumObjectsHidden`, `getSectionBoxDisplay` added in v12.0.0

### DIFF
--- a/bim_webviewer/bim_web_viewer.md
+++ b/bim_webviewer/bim_web_viewer.md
@@ -2579,38 +2579,6 @@ Model
 
 ---
 
-### Get Number Of Objects Selected
-
-<p class="heading-link-container"><a class="heading-link" href="#get-number-of-objects-selected"></a></p>
-
-```js
-getNumObjectsSelected(method);
-```
-
-#### Description
-
-Retrieve the number of objects selected base on the count method. 
-
-#### Parameters
-
-| Field Name | Required | Type | Description |
-| - | - | - | - |
-| method | false | string |  Method to count, can be the following: `FirstObject`, `Object`, or `Geometry`. Default value is `FirstObject` |
-
-##### Returns
-
-```js
-{
-  count: number
-}
-```
-
-##### Namespace
-
-Model
-
----
-
 ### Get Object
 
 <p class="heading-link-container"><a class="heading-link" href="#get-object"></a></p>
@@ -2653,7 +2621,6 @@ Returns a model object with the given id. Contains data such as bounding box, hi
 Model
 
 ---
-
 
 ### Get Objects
 
@@ -2774,7 +2741,6 @@ boolean
 Model
 
 ---
-
 
 ### Hide All Objects
 
@@ -3040,6 +3006,39 @@ number[]
 Model
 
 ---
+
+### Get Number Of Objects Selected
+
+<p class="heading-link-container"><a class="heading-link" href="#get-number-of-objects-selected"></a></p>
+
+```js
+getNumObjectsSelected(method);
+```
+
+#### Description
+
+Retrieve the number of objects selected base on the count method. 
+
+#### Parameters
+
+| Field Name | Required | Type | Description |
+| - | - | - | - |
+| method | false | string |  Method to count, can be the following: `FirstObject`, `Object`, or `Geometry`. Default value is `FirstObject` |
+
+##### Returns
+
+```js
+{
+  count: number
+}
+```
+
+##### Namespace
+
+Model
+
+---
+
 
 ### Set X Ray Mode
 

--- a/bim_webviewer/bim_web_viewer.md
+++ b/bim_webviewer/bim_web_viewer.md
@@ -2859,6 +2859,36 @@ Model
 
 ---
 
+### Get Number Of Objects Hidden
+
+<p class="heading-link-container"><a class="heading-link" href="#get-number-of-objects-hidden"></a></p>
+
+```js
+getNumObjectsHidden();
+```
+
+#### Description
+
+Retrieve the number of objects selected based on the `FirstObject` counting method.
+
+#### Parameters
+
+None
+
+##### Returns
+
+```js
+{
+  count: number
+}
+```
+
+##### Namespace
+
+Model
+
+---
+
 ### Select Objects
 
 <p class="heading-link-container"><a class="heading-link" href="#select-objects"></a></p>
@@ -3017,7 +3047,7 @@ getNumObjectsSelected(method);
 
 #### Description
 
-Retrieve the number of objects selected base on the count method. 
+Retrieve the number of objects selected based on the count method.
 
 #### Parameters
 

--- a/bim_webviewer/bim_web_viewer.md
+++ b/bim_webviewer/bim_web_viewer.md
@@ -2182,6 +2182,34 @@ Model
 
 ---
 
+### Reset Section Box
+
+<p class="heading-link-container"><a class="heading-link" href="#reset-section-box"></a></p>
+
+```js
+resetSectionBox();
+```
+
+#### Description
+
+Resets section box to global bounding box of model.
+
+#### Parameters
+
+None
+
+##### Returns
+
+```js
+undefined
+```
+
+##### Namespace
+
+Model
+
+---
+
 ### Toggle Section Box Display
 
 <p class="heading-link-container"><a class="heading-link" href="#toggle-section-box-display"></a></p>

--- a/bim_webviewer/bim_web_viewer.md
+++ b/bim_webviewer/bim_web_viewer.md
@@ -2324,6 +2324,43 @@ Model
 
 ---
 
+### Get Section Box Display
+
+<p class="heading-link-container"><a class="heading-link" href="#get-section-box-display"></a></p>
+
+```ts
+getSectionBoxDisplay();
+```
+
+#### Description
+
+Gets the current section box display status.
+
+#### Parameters
+
+None
+
+##### Returns
+
+```ts
+{
+  enabled: boolean,
+  configuration: ConfigureSectionBoxDisplayConfig,
+  bbox: {
+    min: { x: number, y: number, z: number },
+    max: { x: number, y: number, z: number },
+  },
+}
+```
+
+For `ConfigureSectionBoxDisplayConfig` schema, see [`model.configureSectionBoxDisplay`](#configure-section-box-display).
+
+##### Namespace
+
+Model
+
+---
+
 ### Add Section Plane
 
 <p class="heading-link-container"><a class="heading-link" href="#add-section-plane"></a></p>


### PR DESCRIPTION
Forgot to document these methods 😵‍💫

## `resetSectionBox`

![image](https://github.com/procore/documentation/assets/2865469/2fdca19c-2920-4e97-b042-9f76cde46c01)

## `getNumObjectsHidden`

I also moved the analogous `getNumObjectsSelected` to be collocated with selection methods. It was in a kind of random place it felt before.

![image](https://github.com/procore/documentation/assets/2865469/25f730f6-6c71-49a1-9c8d-0f4546b1f486)


## `getSectionBoxDisplay`

![image](https://github.com/procore/documentation/assets/2865469/7151d57d-014d-4dee-8dd6-cf159ad2da09)
