### PR TITLE
added webrick to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ group :jekyll_plugins do
 end
 
 gem "minima", "~> 2.5"
+gem "webrick", "~> 1.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,6 +255,7 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (1.8.0)
+    webrick (1.9.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -266,6 +267,7 @@ DEPENDENCIES
   github-pages (~> 214)
   jekyll-feed (~> 0.12)
   minima (~> 2.5)
+  webrick (~> 1.9)
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
Using `ruby 3.1.6p260 (2024-05-29 revision a777087be6) [x64-mingw-ucrt]`, Jekyll serve fails on Ruby 3+ (https://github.com/jekyll/jekyll/issues/8523)