### PR TITLE
PPC2-4815: update upload doc

### DIFF
--- a/tutorials/tutorial_uploads.md
+++ b/tutorials/tutorial_uploads.md
@@ -334,17 +334,17 @@ The following endpoints may also be used to move uploaded files into Procore dep
 
 ## Using upload id in API Requests
 
-This section provides examples of how to use the upload UUID when integrating with various Procore endpoints.
+This section provides examples of how to use the upload id when integrating with various Procore endpoints.
 
 ### What is upload_id?
-The `upload_id` refers to a unique identifier (UUID) created during Procore's direct S3 upload process. 
-This identifier represents a file that has been uploaded directly to Amazon S3 storage, bypassing the older Network File System (NFS) upload method.
+The `upload_id` refers to a unique identifier created during Procore's direct S3 upload process. 
+This identifier represents a file that has been uploaded directly to Amazon S3 storage.
 
 When a file is uploaded via the direct S3 method:
 
-1. An upload record is created with a UUID
+1. An upload record is created with a upload_id
 2. The file is uploaded directly to S3 from the client
-3. The upload_id (UUID) can then be referenced in subsequent API calls to associate the file with specific Procore resources
+3. The upload_id can then be referenced in subsequent API calls to associate the file with specific Procore resources
 
 
 > IMPORTANT CONSIDERATIONS
@@ -353,9 +353,9 @@ When a file is uploaded via the direct S3 method:
 > and the legacy approach, but the upload_id method is strongly preferred for new implementations
 > due to its superior performance and resilience characteristics.
 
-### Example-1: Using Upload UUID with Action Plans
+### Example-1: Using Upload id with Action Plans
 
-When creating a test record attachment in the Action Plans tool, you can reference your uploaded file using its UUID:
+When creating a test record attachment in the Action Plans tool, you can reference your uploaded file using its id:
  
 - Request Method: `POST`
 - Request URL: `/rest/v1.0/projects/1/action_plans/plan_test_records`
@@ -400,8 +400,8 @@ Response Body
 }
 ```
 
-### Example-2: Using Upload UUID with Meeting Topics
-You can create and update Meeting Topics with file attachments by referencing the upload UUID:
+### Example-2: Using Upload id with Meeting Topics
+You can create and update Meeting Topics with file attachments by referencing the upload id:
 
 Creating a Meeting Topic with an attachment:
 

--- a/tutorials/tutorial_uploads.md
+++ b/tutorials/tutorial_uploads.md
@@ -358,7 +358,7 @@ When creating a test record attachment in the Action Plans tool, you can referen
     "type": "attachment",
     "payload": {
       "attachment": {
-        "upload_id": "01JCXCY98883QK2N6X09SASR06"
+        "upload_id": "01JN2W87CCGXZBJFTW5YEDSPRRR"
       }
     }
   }
@@ -377,7 +377,7 @@ Response Body
       "content_type": null,
       "name": "test_filename",
       "thumbnail_url": null,
-      "url": "http://storage.procore.com/api/v5/files/us-east-1/pro-core.com-staging/companies/2/01JN2W87CCGXZBJFTW5YEDSP9R?companyId=2&projectId=1&sig=e947909ff7f84d3b279af3059f049339262d0eac9f1bfa7170702f1899a2560c",
+      "url": "http://storage.procore.com/api/v5/files/us-east-1/pro-core.com-staging/companies/2/01JN2W87CCGXZBJFTW5YEDSPRRR?companyId=2&projectId=1&sig=e947909ff7f84d3b279af3059frd049339262d0eac9f1bfa7170702f1899a2560c",
       "viewer_url": "/webclients/host/companies/2/projects/1/tools/document-viewer/prostore/540?item_id=128&item_type=ActionPlans::Plan::TestRecord&parent_id=6&plan_item_id=49&fullscreen"
     }
   },
@@ -404,7 +404,7 @@ Creating a Meeting Topic with an attachment:
     "meeting_topic": {
         "title": "Creating a meeting topic with upload_ids",
         "description": "Fresh Create Meeting Topic with upload_ids",
-        "upload_ids": ["01JNNGH4ZPX76PVYJX10A0Y5N8"]
+        "upload_ids": ["01JNNGH4ZPX76PVYJX10A0Y5N9"]
     }
 }
 ```
@@ -433,7 +433,7 @@ Creating a Meeting Topic with an attachment:
             "id": 971407,
             "filename": "test_filename",
             "name": "test_filename",
-            "url": "https://pz01-procore-7fbab796.cse.procoretech-qa.com/fas/api/v5/files/us-east-1/pro-core.com-staging/companies/2/01JNNGH4ZPX76PVYJX10A0Y5N8?companyId=2&projectId=1&sig=564988041be708bfda9c52ccc0074809b18fb7f0c629a25d6798375b7223c618"
+            "url": "http://storage.procore.com/api/v5/files/us-east-1/pro-core.com-staging/companies/2/01JNNGH4ZPX76PVYJX10A0Y5N9?companyId=2&projectId=1&sig=564988041be708bfda9c52ccc0074809b18fb7f0c629a25d6798375b7223c618"
         }
     ]
 }
@@ -452,7 +452,7 @@ Creating a Meeting Topic with an attachment:
     "meeting_topic": {
         "title": "Updating meeting topic with an upload_id",
         "description": "Updated Description",
-        "upload_ids": ["01JNNDN3MVJ47BHA2NQR6R5F8C"]
+        "upload_ids": ["01JNNDN3MVJ57BHA2NQR6R5F8D"]
     }
 }
 ```
@@ -481,7 +481,7 @@ Creating a Meeting Topic with an attachment:
             "id": 971406,
             "filename": "test_filename",
             "name": "test_filename",
-            "url": "https://pz01-procore-7fbab796.cse.procoretech-qa.com/fas/api/v5/files/us-east-1/pro-core.com-staging/companies/2/01JNNDN3MVJ47BHA2NQR6R5F8C?companyId=2&projectId=1&sig=e0179fd949a9a0504f7859be2d23575d01f0dfcc0e4adf320413808581b9c90e"
+            "url": "http://storage.procore.com/api/v5/files/us-east-1/pro-core.com-staging/companies/2/01JNNDN3MVJ57BHA2NQR6R5F8D?companyId=2&projectId=1&sig=e0179fd949a9a0505f7859be2d23575d01f0dfcc0e4adf320413808581b9c90e"
         }
     ]
 }

--- a/tutorials/tutorial_uploads.md
+++ b/tutorials/tutorial_uploads.md
@@ -45,13 +45,8 @@ First, we use the `split` command to divide the original source file into multip
 
 `split -b 6000000 test-video-file.mp4 file-segment`
 
-`-b 6000000` specifies the segment size in bytes (6MB), which satisfies AWS's requirement that multipart upload segments be at least 5MB in size.
-
-`test-video-file.mp4` is the source file that will be divided into multiple segments.
-
-`file-segment` is the prefix for the output files, which will be named file-segmentaa, file-segmentab, etc.
-
-After executing the command, we can see that two segments have been created.
+where `-b 6000000` specifies the number of bytes for the minimum segment size (at least 5MB as required), `test-video-file.mp4` is the name of the file to split, and `file-segment` is the prefix that will be used for naming the segments.
+Running this command results in two file segments being created.
 
 `6000000 Mar 25 14:57 file-segmentaa`
 
@@ -255,13 +250,7 @@ A sample POST request to the [Create Upload](https://developers.procore.com/refe
 
 - Request Method: `POST`
 - Request URL: `https://api.procore.com/rest/v1.0/companies/{company_id}/uploads`
-- Request Body (optional): 
-```
-{
-    "response_filename": "example.pdf",
-    "response_content_type": "application/pdf"
-}
-```
+- Request Body (optional): `{ "response_filename": "example.pdf", "response_content_type": "application/pdf" }`
 
 Including the optional `response_filename` in the request body ensures that the storage service is aware of the filename for the upload in advance.
 Since files are often downloaded directly from the storage service, specifying the `response_filename` ensures that the file will save on an end user's device with a meaningful name and extension.

--- a/tutorials/tutorial_uploads.md
+++ b/tutorials/tutorial_uploads.md
@@ -332,7 +332,7 @@ The following endpoints may also be used to move uploaded files into Procore dep
 - [Create Project File](https://developers.procore.com/reference/rest/v1/project-folders-and-files#create-project-file)
 
 
-## Using Upload UUID in API Requests
+## Using upload id in API Requests
 
 This section provides examples of how to use the upload UUID when integrating with various Procore endpoints.
 

--- a/tutorials/tutorial_uploads.md
+++ b/tutorials/tutorial_uploads.md
@@ -45,8 +45,13 @@ First, we use the `split` command to divide the original source file into multip
 
 `split -b 6000000 test-video-file.mp4 file-segment`
 
-where `-b 6000000` specifies the number of bytes for the minimum segment size (at least 5MB as required), `test-video-file.mp4` is the name of the file to split, and `file-segment` is the prefix that will be used for naming the segments.
-Running this command results in two file segments being created.
+`-b 6000000` specifies the segment size in bytes (6MB), which satisfies AWS's requirement that multipart upload segments be at least 5MB in size.
+
+`test-video-file.mp4` is the source file that will be divided into multiple segments.
+
+`file-segment` is the prefix for the output files, which will be named file-segmentaa, file-segmentab, etc.
+
+After executing the command, we can see that two segments have been created.
 
 `6000000 Mar 25 14:57 file-segmentaa`
 
@@ -250,7 +255,13 @@ A sample POST request to the [Create Upload](https://developers.procore.com/refe
 
 - Request Method: `POST`
 - Request URL: `https://api.procore.com/rest/v1.0/companies/{company_id}/uploads`
-- Request Body (optional): `{ "response_filename": "example.pdf", "response_content_type": "application/pdf" }`
+- Request Body (optional): 
+```
+{
+    "response_filename": "example.pdf",
+    "response_content_type": "application/pdf"
+}
+```
 
 Including the optional `response_filename` in the request body ensures that the storage service is aware of the filename for the upload in advance.
 Since files are often downloaded directly from the storage service, specifying the `response_filename` ensures that the file will save on an end user's device with a meaningful name and extension.
@@ -319,3 +330,178 @@ The following endpoints may also be used to move uploaded files into Procore dep
 - [Create Image](https://developers.procore.com/reference/rest/v1/images#create-image)
 - [Create Drawing Upload](https://developers.procore.com/reference/rest/v1/drawings#create-drawing-upload)
 - [Create Project File](https://developers.procore.com/reference/rest/v1/project-folders-and-files#create-project-file)
+
+
+## Using Upload UUID in API Requests
+
+This section provides examples of how to use the upload UUID when integrating with various Procore endpoints.
+
+### What is upload_id?
+The `upload_id` refers to a unique identifier (UUID) created during Procore's direct S3 upload process. 
+This identifier represents a file that has been uploaded directly to Amazon S3 storage, bypassing the older Network File System (NFS) upload method.
+
+When a file is uploaded via the direct S3 method:
+
+1. An upload record is created with a UUID
+2. The file is uploaded directly to S3 from the client
+3. The upload_id (UUID) can then be referenced in subsequent API calls to associate the file with specific Procore resources
+
+
+> IMPORTANT CONSIDERATIONS 
+> 
+> The system is designed to maintain compatibility with both new direct S3 uploads using upload_id 
+> and the legacy NFS approach, but the direct S3 method is strongly preferred for new implementations 
+> due to its superior performance characteristics.
+
+### Example-1: Using Upload UUID with Action Plans
+
+When creating a test record attachment in the Action Plans tool, you can reference your uploaded file using its UUID:
+ 
+- Request Method: `POST`
+- Request URL: `/rest/v1.0/projects/1/action_plans/plan_test_records`
+- Request Body:
+
+```
+{
+  "plan_test_record": {
+    "plan_item_id": 54,
+    "plan_test_record_request_id": 42,
+    "type": "attachment",
+    "payload": {
+      "attachment": {
+        "upload_id": "01JCXCY98883QK2N6X09SASR06"
+      }
+    }
+  }
+}
+```
+
+Response Body
+
+```
+{
+  "id": 128,
+  "created_at": "2025-02-28T09:12:13Z",
+  "payload": {
+    "attachment": {
+      "id": 540,
+      "content_type": null,
+      "name": "test_filename",
+      "thumbnail_url": null,
+      "url": "http://storage.procore.com/api/v5/files/us-east-1/pro-core.com-staging/companies/2/01JN2W87CCGXZBJFTW5YEDSP9R?companyId=2&projectId=1&sig=e947909ff7f84d3b279af3059f049339262d0eac9f1bfa7170702f1899a2560c",
+      "viewer_url": "/webclients/host/companies/2/projects/1/tools/document-viewer/prostore/540?item_id=128&item_type=ActionPlans::Plan::TestRecord&parent_id=6&plan_item_id=49&fullscreen"
+    }
+  },
+  "plan_id": 6,
+  "plan_item_id": 49,
+  "plan_test_record_request_id": 50,
+  "type": "attachment",
+  "updated_at": "2025-02-28T09:12:13Z"
+}
+```
+
+### Example-2: Using Upload UUID with Meeting Topics
+You can create and update Meeting Topics with file attachments by referencing the upload UUID:
+
+Creating a Meeting Topic with an attachment:
+
+- Request Method: `POST`
+- Request URL: `/rest/v1.1/projects/{project_id}/meeting_topics`
+- Request Body:
+
+```
+{
+    "meeting_id": 538,
+    "meeting_topic": {
+        "title": "Creating a meeting topic with upload_ids",
+        "description": "Fresh Create Meeting Topic with upload_ids",
+        "upload_ids": ["01JNNGH4ZPX76PVYJX10A0Y5N8"]
+    }
+}
+```
+
+- Response Body
+
+```
+{
+    "id": 535,
+    "number": "1.5",
+    "created_on": "2025-03-06",
+    "position": 5,
+    "due_date": null,
+    "priority": null,
+    "status": "Open",
+    "title": "Creating a meeting topic with upload_ids",
+    "minutes": null,
+    "description": "Fresh Create Meeting Topic with upload_ids",
+    "meeting_category": {
+        "id": 202,
+        "title": "Uncategorized Items"
+    },
+    "assignments": [],
+    "attachments": [
+        {
+            "id": 971407,
+            "filename": "test_filename",
+            "name": "test_filename",
+            "url": "https://pz01-procore-7fbab796.cse.procoretech-qa.com/fas/api/v5/files/us-east-1/pro-core.com-staging/companies/2/01JNNGH4ZPX76PVYJX10A0Y5N8?companyId=2&projectId=1&sig=564988041be708bfda9c52ccc0074809b18fb7f0c629a25d6798375b7223c618"
+        }
+    ]
+}
+```
+
+
+### Example-3 Updating a Meeting Topic with an attachment:
+
+- Request Method: `PATCH`
+- Request URL: `/rest/v1.1/projects/{project_id}/meeting_topics/{id}`
+- Request Body:
+
+```
+{
+    "meeting_id": 538,
+    "meeting_topic": {
+        "title": "Updating meeting topic with an upload_id",
+        "description": "Updated Description",
+        "upload_ids": ["01JNNDN3MVJ47BHA2NQR6R5F8C"]
+    }
+}
+```
+
+- Response Body
+
+```
+{
+    "id": 534,
+    "number": "1.4",
+    "created_on": "2025-03-06",
+    "position": 4,
+    "due_date": null,
+    "priority": null,
+    "status": "Open",
+    "title": "Updating as form data key value with an attachment",
+    "minutes": null,
+    "description": "Updated Description",
+    "meeting_category": {
+        "id": 202,
+        "title": "Uncategorized Items"
+    },
+    "assignments": [],
+    "attachments": [
+        {
+            "id": 971406,
+            "filename": "test_filename",
+            "name": "test_filename",
+            "url": "https://pz01-procore-7fbab796.cse.procoretech-qa.com/fas/api/v5/files/us-east-1/pro-core.com-staging/companies/2/01JNNDN3MVJ47BHA2NQR6R5F8C?companyId=2&projectId=1&sig=e0179fd949a9a0504f7859be2d23575d01f0dfcc0e4adf320413808581b9c90e"
+        }
+    ]
+}
+```
+
+## Migrating from Legacy Uploads
+If you're currently using the legacy direct upload approach, we strongly recommend migrating to the `upload_id` approach. The benefits include:
+
+- Improved upload performance and reliability
+- Reduced API request payload sizes
+- Better handling of large files
+- More consistent behavior across different Procore tools

--- a/tutorials/tutorial_uploads.md
+++ b/tutorials/tutorial_uploads.md
@@ -347,11 +347,11 @@ When a file is uploaded via the direct S3 method:
 3. The upload_id (UUID) can then be referenced in subsequent API calls to associate the file with specific Procore resources
 
 
-> IMPORTANT CONSIDERATIONS 
-> 
-> The system is designed to maintain compatibility with both new direct S3 uploads using upload_id 
-> and the legacy NFS approach, but the direct S3 method is strongly preferred for new implementations 
-> due to its superior performance characteristics.
+> IMPORTANT CONSIDERATIONS
+>
+> The system is designed to maintain compatibility with both new direct uploads using upload_id
+> and the legacy approach, but the upload_id method is strongly preferred for new implementations
+> due to its superior performance and resilience characteristics.
 
 ### Example-1: Using Upload UUID with Action Plans
 

--- a/tutorials/tutorial_uploads.md
+++ b/tutorials/tutorial_uploads.md
@@ -488,7 +488,7 @@ Creating a Meeting Topic with an attachment:
 ```
 
 ## Migrating from Legacy Uploads
-If you're currently using the legacy direct upload approach (via `attachments` or `data` attributes), we strongly recommend migrating to the `upload_id` approach. The benefits include:
+If you're currently using the legacy upload approach (via `attachments` or `data` attributes), we strongly recommend migrating to the `upload_id` approach. The benefits include:
 
 - Improved upload performance and reliability
 - Reduced API request payload sizes

--- a/tutorials/tutorial_uploads.md
+++ b/tutorials/tutorial_uploads.md
@@ -488,7 +488,7 @@ Creating a Meeting Topic with an attachment:
 ```
 
 ## Migrating from Legacy Uploads
-If you're currently using the legacy direct upload approach, we strongly recommend migrating to the `upload_id` approach. The benefits include:
+If you're currently using the legacy direct upload approach (via `attachments` or `data` attributes), we strongly recommend migrating to the `upload_id` approach. The benefits include:
 
 - Improved upload performance and reliability
 - Reduced API request payload sizes


### PR DESCRIPTION
### JIRA [PPC2-4815](https://procoretech.atlassian.net/browse/PPC2-4815)

Update API documentation to reflect use of upload_id.

This PR updates the API documentation to fully document the upload_id approach for file uploads.
This aligns with our broader effort to migrate away from NFS-based file uploads to the more performant, reliable S3 direct upload methodology. 

## Changes

- Added documentation for using `upload_id` with various endpoints (Action Plans, Meeting Topics)
- Added examples showing proper usage of `upload_id` in API requests and responses
- Included migration recommendations for developers still using legacy approaches
- Emphasized performance and reliability improvements with the `upload_id` approach

## Files Changed

- Added new documentation section explaining the `upload_id` concept and implementation
- Added specific examples showing proper request and response formats

## Screenshots.
> <img width="593" alt="image" src="https://github.com/user-attachments/assets/eaff2495-71a2-48fc-97f9-d5f772011c30" />
--- 
> <img width="585" alt="image" src="https://github.com/user-attachments/assets/372f8faf-06b6-4e8a-bf06-bc17cca1396e" />
--- 
> <img width="577" alt="image" src="https://github.com/user-attachments/assets/69b417e5-cbef-4126-ac65-bc8dccdee17c" />




[PPC2-4815]: https://procoretech.atlassian.net/browse/PPC2-4815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ