### PR TITLE
Updating FedRAMP Docs per feedback and some changes to Partner Items

### DIFF
--- a/_includes/app_marketplace_legal_disclaimer.md
+++ b/_includes/app_marketplace_legal_disclaimer.md
@@ -1,0 +1,4 @@
+### Updates to Guidelines and Enforcement
+Procore Technologies reserves the right to revise the Developer Documentation at any time.
+
+As outlined in our terms and conditions, Procore may remove or decline the publication of any Marketplace listing at its discretion.

--- a/_includes/need_help_section.md
+++ b/_includes/need_help_section.md
@@ -1,0 +1,32 @@
+## Need Help?
+We’re here to support you at every step of your journey. Here’s how to get help:
+<br><br>
+<table>
+  <thead>
+    <tr>
+      <th>Type of Help</th>
+      <th>Contact</th>
+      <th>What They Support</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>API & Technical Support</strong></td>
+      <td><a href="https://developers.procore.com/developer_support">apisupport@procore.com</a></td>
+      <td>Issues with APIs, authentication, Sandbox, and app types</td>
+    </tr>
+    <tr>
+      <td><strong>Technology Partner Program</strong></td>
+      <td><a href="mailto:techpartners@procore.com">techpartners@procore.com</a></td>
+      <td>Questions about agreements, vetting, or intake process</td>
+    </tr>
+    <tr>
+      <td><strong>Marketplace QA</strong></td>
+      <td><a href="mailto:marketplaceqa@procore.com">marketplaceqa@procore.com</a></td>
+      <td>App review status, listing changes, and validation feedback</td>
+    </tr>
+  </tbody>
+</table>
+<br>
+You can also explore our learning tools and support resources in the [Help & Learning Center]({{ site.url }}{{ site.baseurl }}{% link overview/help_and_learning_center.md %}).
+<br><br>

--- a/app_marketplace/listing_your_app.md
+++ b/app_marketplace/listing_your_app.md
@@ -71,42 +71,7 @@ For additional validation details, see the [Marketplace Approval Checklist]({{ s
 <br><br>
 
 ***
-## Need Help?
-We’re here to support you at every step of your journey. Here’s how to get help:
-<br><br>
-<table>
-  <thead>
-    <tr>
-      <th>Type of Help</th>
-      <th>Contact</th>
-      <th>What They Support</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><strong>API & Technical Support</strong></td>
-      <td><a href="https://developers.procore.com/developer_support">apisupport@procore.com</a></td>
-      <td>Issues with APIs, authentication, Sandbox, and app types</td>
-    </tr>
-    <tr>
-      <td><strong>Technology Partner Program</strong></td>
-      <td><a href="mailto:techpartners@procore.com">techpartners@procore.com</a></td>
-      <td>Questions about agreements, vetting, or intake process</td>
-    </tr>
-    <tr>
-      <td><strong>Marketplace QA</strong></td>
-      <td><a href="mailto:marketplaceqa@procore.com">marketplaceqa@procore.com</a></td>
-      <td>App review status, listing changes, and validation feedback</td>
-    </tr>
-  </tbody>
-</table>
-<br>
-You can also explore our learning tools and support resources in the [Help & Learning Center]({{ site.url }}{{ site.baseurl }}{% link overview/help_and_learning_center.md %}).
-<br><br>
+{% include need_help_section.md %}
 
 ***
-### Updates to Guidelines and Enforcement
-
-Procore Technologies reserves the right to revise the Developer Documentation at any time,  in its sole discretion.
-
-As described in the applicable terms and conditions, Procore may remove or decline the publication of any Marketplace listing at any time.
+{% include app_marketplace_legal_disclaimer.md %}

--- a/app_marketplace/market_your_app.md
+++ b/app_marketplace/market_your_app.md
@@ -71,8 +71,4 @@ We encourage you to use these resources to create co-branded content that aligns
 <br><br>
 
 ***
-### Updates to Guidelines and Enforcement
-
-Procore Technologies reserves the right to revise the Developer Documentation at any time, in its sole discretion.
-
-As described in the applicable terms and conditions, Procore may remove or decline the publication of any Marketplace listing or co-marketing opportunity at any time.
+{% include app_marketplace_legal_disclaimer.md %}

--- a/app_marketplace/marketplace_checklist.md
+++ b/app_marketplace/marketplace_checklist.md
@@ -171,7 +171,4 @@ For more details about the Monthly Sandbox, including the refresh schedule and a
 <br><br>
 
 ***
-### Updates to Guidelines and Enforcement
-Procore Technologies reserves the right to revise the Developer Documentation at any time,  in its sole discretion.
-
-As described in the applicable terms and conditions, Procore may remove or decline the publication of any Marketplace listing at any time.
+{% include app_marketplace_legal_disclaimer.md %}

--- a/app_marketplace/marketplace_listing_guidelines.md
+++ b/app_marketplace/marketplace_listing_guidelines.md
@@ -167,8 +167,4 @@ You can decide whether to allow customers to install your app directly from the 
 <br><br>
 
 ***
-### Updates to Guidelines and Enforcement
-
-Procore Technologies reserves the right to revise the Developer Documentation at any time, in its sole discretion.
-
-As described in the applicable terms and conditions, Procore may remove or decline the publication of any Marketplace listing at any time.
+{% include app_marketplace_legal_disclaimer.md %}

--- a/app_marketplace/marketplace_requirements.md
+++ b/app_marketplace/marketplace_requirements.md
@@ -99,56 +99,8 @@ Once your app is live on the Marketplace, it's important to maintain quality and
 Procore may remove or unlist apps that do not meet ongoing requirements.
 <br><br>
 
-<!-- ***
-## Marketplace Readiness Checklist
-Before applying to become a Technology Partner, confirm:
-
-<input type="checkbox"> Clear customer value is demonstrated<br>
-<input type="checkbox"> Intuitive and user-friendly experience<br>
-<input type="checkbox"> Security and data privacy measures are in place<br>
-<input type="checkbox"> Comprehensive support documentation created<br>
-<input type="checkbox"> Procore branding guidelines followed<br>
-<input type="checkbox"> Thorough application testing completed<br>
-<input type="checkbox"> Required listing assets (icons, screenshots, etc.) prepared<br>
-
-See the full [Marketplace Approval Checklist]({{ site.url }}{{ site.baseurl }}{% link app_marketplace/marketplace_checklist.md %}) for additional details. -->
+***
+{% include need_help_section.md %}
 
 ***
-## Need Help?
-We’re here to support you at every step of your journey. Here’s how to get help:
-<br><br>
-<table>
-  <thead>
-    <tr>
-      <th>Type of Help</th>
-      <th>Contact</th>
-      <th>What They Support</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><strong>API & Technical Support</strong></td>
-      <td><a href="https://developers.procore.com/developer_support">apisupport@procore.com</a></td>
-      <td>Issues with APIs, authentication, Sandbox, and app types</td>
-    </tr>
-    <tr>
-      <td><strong>Technology Partner Program</strong></td>
-      <td><a href="mailto:techpartners@procore.com">techpartners@procore.com</a></td>
-      <td>Questions about agreements, vetting, or intake process</td>
-    </tr>
-    <tr>
-      <td><strong>Marketplace QA</strong></td>
-      <td><a href="mailto:marketplaceqa@procore.com">marketplaceqa@procore.com</a></td>
-      <td>App review status, listing changes, and validation feedback</td>
-    </tr>
-  </tbody>
-</table>
-<br>
-You can also explore our learning tools and support resources in the [Help & Learning Center]({{ site.url }}{{ site.baseurl }}{% link overview/help_and_learning_center.md %}).
-<br><br>
-
-***
-### Updates to Guidelines and Enforcement
-Procore Technologies reserves the right to modify the Developer Documentation at any time, in its sole discretion.
-
-As described in the applicable terms and conditions, Procore may remove or decline the publication of any Marketplace listing at any time.
+{% include app_marketplace_legal_disclaimer.md %}

--- a/app_marketplace/procore_partner_overview.md
+++ b/app_marketplace/procore_partner_overview.md
@@ -112,8 +112,4 @@ We recommend reviewing our <a target="_blank" href="https://downloads.ctfassets.
 <br><br>
 
 ***
-### Updates to Guidelines and Enforcement
-
-Procore Technologies reserves the right to revise the Developer Documentation at any time,  in its sole discretion.
-
-As described in the applicable terms and conditions, Procore may remove or decline the publication of any Marketplace listing at any time.
+{% include app_marketplace_legal_disclaimer.md %}

--- a/app_marketplace/update_your_marketplace_app.md
+++ b/app_marketplace/update_your_marketplace_app.md
@@ -35,7 +35,7 @@ If you're unable to access the app in the Developer Portal, see [Managing App Co
   <br><br>
 
   <p><b>Best Practices</b></p>
-  A  A well-crafted listing helps attract the right audience and improve discoverability. For guidance on optimizing your listing content, see <a href="{{ site.url }}{{ site.baseurl }}{% link app_marketplace/marketplace_listing_guidelines.md %}">Marketplace Listing Guidelines</a>.
+  A well-crafted listing helps attract the right audience and improve discoverability. For guidance on optimizing your listing content, see <a href="{{ site.url }}{{ site.baseurl }}{% link app_marketplace/marketplace_listing_guidelines.md %}">Marketplace Listing Guidelines</a>.
 </details>
 
 ***
@@ -115,9 +115,9 @@ Publishing your app on the Procore Marketplace is just the first step toward sca
 
 ### Leverage Procore’s Marketing Guides
 To support your go-to-market and growth strategies, Procore provides a suite of self-service partner guides that offer actionable tactics and recommendations. Rather than duplicating this guidance, we encourage you to explore the full details in each guide below:
-- <b><a href="https://docs.google.com/document/d/1STqajJQ3n1w0lHtM5qyhxutHMqyKHOsbF7_aK0Urh30/edit?usp=sharing" target="_blank">Partner How-To: Promote My Application</a></b>: Tips for creating a compelling Marketplace listing, promoting your app across digital channels, and aligning with Procore’s marketing resources.
-- <b><a href="https://docs.google.com/document/d/1YtJXPrPcNW1drPU19jtJD2mPKHDcI5ugrzL7KpTvvS4/edit?usp=sharing" target="_blank">Partner How-To: Increase Integration Adoption & Usage</a></b>: Strategies for training your teams, enabling customer success, and building long-term usage momentum.
-- <b><a href="https://docs.google.com/document/d/1QiRnVVj5vYSYTcmAfzYCotqnHw9GFkYUL9UEyZ2XcYY/edit?usp=sharing" target="_blank">Partner How-To: Elevate My Integration</a></b>: Best practices for enhancing the technical quality, reliability, and user experience of your app.
+- <b><a href="https://www.procore.com/cdn/downloads/partner-how-to-promote-my-application" target="_blank">Partner How-To: Promote My Application</a></b>: Tips for creating a compelling Marketplace listing, promoting your app across digital channels, and aligning with Procore’s marketing resources.
+- <b><a href="https://www.procore.com/cdn/downloads/partner-how-to-increase-integration-adoption-usage" target="_blank">Partner How-To: Increase Integration Adoption & Usage</a></b>: Strategies for training your teams, enabling customer success, and building long-term usage momentum.
+- <b><a href="https://www.procore.com/cdn/downloads/partner-how-to-elevate-my-integration" target="_blank">Partner How-To: Elevate My Integration</a></b>: Best practices for enhancing the technical quality, reliability, and user experience of your app.
 
 These resources are designed to help you grow efficiently and successfully within the Procore ecosystem. For questions, contact <a href="mailto:techpartners@procore.com">techpartners@procore.com</a>.
 
@@ -158,7 +158,4 @@ Stay informed about Procore API changes through Developer Portal announcements, 
 <br><br>
 
 ***
-### Updates to Guidelines and Enforcement
-Procore Technologies reserves the right to revise the Developer Documentation at any time.
-
-As outlined in our terms and conditions, Procore may remove or decline the publication of any Marketplace listing at its discretion.
+{% include app_marketplace_legal_disclaimer.md %}

--- a/platform_concepts/federal_zone_overview.md
+++ b/platform_concepts/federal_zone_overview.md
@@ -1,6 +1,7 @@
 ---
 permalink: /federal-zone-overview
 title: Procore Federal Environment Overview
+sub_header: Learn how the Federal Zone differs from Procore’s Commercial environment and what developers need to know.
 layout: default
 section_title: Platform Concepts
 
@@ -35,15 +36,25 @@ The **Federal Risk and Authorization Management Program (FedRAMP)** is a U.S. go
 | Developer Portal Access     | Request required for access                             | Open to registered users                  |
 | Environment Isolation       | Fully separate tenant and infrastructure                | Shared infrastructure                     |
 | Customer Base               | U.S. federal agencies and contractors (U.S. IPs only)   | Global usage                              |
-| App Portability             | Apps must be registered separately; not shareable       | Apps run only in the commercial environment |
-| Sandbox Availability        | Not available                                           | Available                                 |
+| Sandbox Availability        | Not available (no developer or monthly sandboxes)       | Available (developer and monthly sandboxes) |
 | Marketplace                 | Separate Federal Marketplace                            | Procore Marketplace                       |
 
 <div class="details-bottom-spacing"></div>
 
 ***
-## Additional Resources
+
+## Testing Recommendations
+The Federal Zone does not currently offer sandbox environments for testing purposes. This means Procore cannot provision developer or monthly sandbox accounts as it can in the Commercial environment.
+
+To validate your app for the Federal Zone, we recommend:
+- **Develop and test in the Commercial environment first**, using Procore’s available sandbox accounts. Once stable, conduct limited testing in the Federal Zone using production credentials in a tightly controlled staging scenario with non-sensitive sample data and restricted access.
+- **Swapping in the appropriate Federal environment configuration**: This includes the base API URL (`https://api.procoregov.com`), login endpoint (`https://login.procoregov.com`), and your Federal-specific client ID and client secret. These credentials are not interchangeable with those used in the Commercial environment.
+
+While this approach is not a perfect substitute for a full sandbox, it currently offers the best available method for replicating Federal Zone behavior.
+
+***
+### Additional Resources
 - <a target="_blank" href="https://www.fedramp.gov/">What Is FedRAMP?</a>
 - <a target="_blank" href="https://developers.procoregov.com/">Federal Developer Portal</a>
 - <a target="_blank" href="https://marketplace.procoregov.com/">Federal Marketplace</a>
-- For questions or support, contact <a href="mailto:techpartners@procore.com">MarketplaceQA@procore.com</a>.
+- For questions or support, contact <a href="mailto:marketplaceqa@procore.com">MarketplaceQA@procore.com</a>.


### PR DESCRIPTION
- Updating FedRAMP documents per internal feedback (keeping as an unlisted asset/resource) for the time being.
- Small changes to the Partner Docs, including adding the _includes references to template/common items.