### PR TITLE
[COP-669] Contentful integration into Assist service

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -224,6 +224,8 @@
       url: /tutorial-observations
     - title: Project Stages
       url: /tutorial-project-stages
+    - title: Contentful integration into Assist
+      url: /contenful-integration-in-assist
 
 - title: Example Apps & SDKs
   items:

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -225,7 +225,7 @@
     - title: Project Stages
       url: /tutorial-project-stages
     - title: Contentful integration into Assist
-      url: /contenful-integration-in-assist
+      url: /contentful-integration-in-assist
 
 - title: Example Apps & SDKs
   items:

--- a/contentful/contentful.md
+++ b/contentful/contentful.md
@@ -1,0 +1,82 @@
+---
+permalink: /contenful-integration-in-assist
+title: Contentful integration into Assist
+layout: default
+section_title: Contentful API Integration
+---
+
+## Overview
+
+This document describes the Contentful Content Delivery API (CDA) integration, which provides access to content stored in Contentful.
+
+The overall documentation for Contentful can be found [here](https://www.contentful.com/developers/docs/references/content-delivery-api/#/introduction).
+
+## General Contentful API Client
+
+The client is configured via environment variables (the values can be found [here](https://github.com/procore/copilot/blob/main/services/copilot/env.sample)):
+
+```bash
+CONTENTFUL_SPACE_ID=your_space_id
+CONTENTFUL_ACCESS_TOKEN=your_access_token
+CONTENTFUL_HOST=https://cdn.contentful.com
+CONTENTFUL_ENVIRONMENT=master  # defaults to "master"
+```
+
+The default [content_type](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters) for the Assist is `copilotSampleQuestions`.
+
+The locale name styling can be found [here](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/locales).
+
+## API Endpoints
+
+### Get Copilot Sample Questions
+
+```http
+GET /rest/v1.0/copilot/conversations/sample-questions
+```
+
+Fetches random `limit` sample questions for the copilot interface.
+
+**Parameters:**
+
+- `locale` (string): Content locale (default: "en-US")
+- `limit` (integer): Maximum number of entries to return (default: 3)
+
+**Response:**
+
+```json
+{
+  "items": [
+    "How do I create a project?",
+    "What is an RFI?"
+  ]
+}
+```
+
+**Note:** The current implementation only provides the sample questions endpoint. 
+
+### Copilot Usage Examples
+
+#### HTTP Requests
+
+```bash
+curl -H "Authorization: Bearer YOUR_TOKEN" \
+  "http://localhost:5067/rest/v1.0/copilot/conversations/sample-questions?company_id=123&project_id=456"
+
+# Get sample questions with specific locale and limit
+curl -H "Authorization: Bearer YOUR_TOKEN" \
+  "http://localhost:5067/rest/v1.0/copilot/conversations/sample-questions?company_id=123&project_id=456&locale=en-US&limit=5"
+```
+
+#### Python Service Usage
+
+```python
+from copilot.utils.sample_questions_service import SampleQuestionsService
+
+
+service = SampleQuestionsService()
+
+questions = await service.get_copilot_sample_questions(
+    locale="en-US",
+    limit=5
+)
+```

--- a/contentful/contentful.md
+++ b/contentful/contentful.md
@@ -1,5 +1,5 @@
 ---
-permalink: /contenful-integration-in-assist
+permalink: /contentful-integration-in-assist
 title: Contentful integration into Assist
 layout: default
 section_title: Contentful API Integration


### PR DESCRIPTION
Jira Ticket: https://procoretech.atlassian.net/browse/COP-1669

This PR adds the documentation regarding the integration of Contentful Content Delivery API (CDA) integration (https://www.contentful.com/developers/docs/references/content-delivery-api/#/introduction) into the Assist service.

Changes introduced by https://github.com/procore/copilot/pull/2822


https://github.com/user-attachments/assets/663d6549-932b-4d11-9c9e-a592328fdfac

