### PR TITLE
ERP-7227: Add Company Level Direct Costs to ERP developer docs

### DIFF
--- a/erp_integration/erp_events_dictionary.md
+++ b/erp_integration/erp_events_dictionary.md
@@ -2334,11 +2334,11 @@ The ERP Integration is expected to check the state of the prime contract change 
     "request_detail_id": 1,
     "company_id": 7,
     "direct_cost": {
-      "id": "171354581",
-      "accounting_date": "2026-05-01",
-      "ai_autofill": true,
-      "billed_amount": "920.13",
-      "created_at": "2026-05-11T15:09:39Z",
+      "id": "10000001",
+      "accounting_date": "2025-06-01",
+      "ai_autofill": false,
+      "billed_amount": "1000.0",
+      "created_at": "2025-06-01T10:00:00Z",
       "currency_configuration": {
         "base_currency_iso_code": null,
         "currency_exchange_rate": "1.0",
@@ -2346,14 +2346,14 @@ The ERP Integration is expected to check the state of the prime contract change 
       },
       "description": "Invoice description",
       "direct_cost_attachment": {
-        "id": "6192570404",
+        "id": "20000001",
         "content_type": "application/pdf",
-        "created_at": "2026-05-11T15:09:39Z",
+        "created_at": "2025-06-01T10:00:00Z",
         "name": "invoice.pdf",
         "url": "https://storage.procore.com/...",
-        "uuid": "e053c20f079b42ac82bcc09a3ef919568cb5"
+        "uuid": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8"
       },
-      "direct_cost_date": "2026-05-01",
+      "direct_cost_date": "2025-06-01",
       "direct_cost_type": "invoice",
       "discount_date": null,
       "employee": null,
@@ -2371,15 +2371,15 @@ The ERP Integration is expected to check the state of the prime contract change 
           "name": "Test Project"
         }
       ],
-      "received_date": "2026-05-11",
+      "received_date": "2025-06-01",
       "review_status": "ready",
       "status": "approved",
       "terms": null,
-      "updated_at": "2026-05-11T20:01:56Z",
-      "uploaded_at": "2026-05-11T15:09:39Z",
+      "updated_at": "2025-06-01T10:00:00Z",
+      "uploaded_at": "2025-06-01T10:00:00Z",
       "uploaded_by": "user@example.com",
       "vendor": {
-        "id": "18951792",
+        "id": "30000001",
         "name": "Test Vendor",
         "origin_id": "vendor_origin_id",
         "origin_code": "V-00001",
@@ -2390,7 +2390,7 @@ The ERP Integration is expected to check the state of the prime contract change 
       "origin_data": null,
       "line_items": [
         {
-          "id": "385305686",
+          "id": "40000001",
           "company": {
             "id": "7"
           },
@@ -2400,7 +2400,7 @@ The ERP Integration is expected to check the state of the prime contract change 
             "currency_iso_code": "USD"
           },
           "description": "Line item description",
-          "direct_cost_id": "171354581",
+          "direct_cost_id": "10000001",
           "extended_type": "calculated",
           "position": 1,
           "project": {
@@ -2415,9 +2415,9 @@ The ERP Integration is expected to check the state of the prime contract change 
             "read_only": false
           },
           "wbs_code": {
-            "id": "4806434576",
-            "flat_code": "03-10-50.S",
-            "description": "Concrete Coring"
+            "id": "50000001",
+            "flat_code": "01-100",
+            "description": "General Requirements"
           },
           "job_origin_id": "project_origin_id",
           "cost_code_id": 456,
@@ -2440,7 +2440,7 @@ After the company level direct cost has been successfully exported to the ERP sy
   "request_name": "reset_company_level_direct_cost",
   "request_data": {
     "direct_cost": {
-      "id": "171354581"
+      "id": "10000001"
     },
     "origin_id": "direct_cost_origin_id",
     "origin_code": "INV-001",
@@ -2464,11 +2464,11 @@ There are no required actions. If necessary, the ERP Integration can clean up an
     "request_detail_id": 1,
     "company_id": 7,
     "direct_cost": {
-      "id": "171354581",
-      "accounting_date": "2026-05-01",
-      "ai_autofill": true,
-      "billed_amount": "920.13",
-      "created_at": "2026-05-11T15:09:39Z",
+      "id": "10000001",
+      "accounting_date": "2025-06-01",
+      "ai_autofill": false,
+      "billed_amount": "1000.0",
+      "created_at": "2025-06-01T10:00:00Z",
       "currency_configuration": {
         "base_currency_iso_code": "USD",
         "currency_exchange_rate": "1.0",
@@ -2476,14 +2476,14 @@ There are no required actions. If necessary, the ERP Integration can clean up an
       },
       "description": "Invoice description",
       "direct_cost_attachment": {
-        "id": "6192570404",
+        "id": "20000001",
         "content_type": "application/pdf",
-        "created_at": "2026-05-11T15:09:39Z",
+        "created_at": "2025-06-01T10:00:00Z",
         "name": "invoice.pdf",
         "url": "https://storage.procore.com/...",
-        "uuid": "e053c20f079b42ac82bcc09a3ef919568cb5"
+        "uuid": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8"
       },
-      "direct_cost_date": "2026-05-01",
+      "direct_cost_date": "2025-06-01",
       "direct_cost_type": "invoice",
       "discount_date": null,
       "employee": null,
@@ -2501,15 +2501,15 @@ There are no required actions. If necessary, the ERP Integration can clean up an
           "name": "Test Project"
         }
       ],
-      "received_date": "2026-05-11",
+      "received_date": "2025-06-01",
       "review_status": "ready",
       "status": "approved",
       "terms": null,
-      "updated_at": "2026-05-11T20:01:56Z",
-      "uploaded_at": "2026-05-11T15:09:39Z",
+      "updated_at": "2025-06-01T10:00:00Z",
+      "uploaded_at": "2025-06-01T10:00:00Z",
       "uploaded_by": "user@example.com",
       "vendor": {
-        "id": "18951792",
+        "id": "30000001",
         "name": "Test Vendor"
       },
       "origin_id": "direct_cost_origin_id",

--- a/erp_integration/erp_events_dictionary.md
+++ b/erp_integration/erp_events_dictionary.md
@@ -2342,7 +2342,7 @@ The ERP Integration is expected to check the state of the prime contract change 
       "currency_configuration": {
         "base_currency_iso_code": null,
         "currency_exchange_rate": "1.0",
-        "currency_iso_code": null
+        "currency_iso_code": "USD"
       },
       "description": "Invoice description",
       "direct_cost_attachment": {
@@ -2397,7 +2397,7 @@ The ERP Integration is expected to check the state of the prime contract change 
           "currency_configuration": {
             "base_currency_iso_code": null,
             "currency_exchange_rate": "1.0",
-            "currency_iso_code": null
+            "currency_iso_code": "USD"
           },
           "description": "Line item description",
           "direct_cost_id": "10000001",
@@ -2472,7 +2472,7 @@ There are no required actions. If necessary, the ERP Integration can clean up an
       "currency_configuration": {
         "base_currency_iso_code": null,
         "currency_exchange_rate": "1.0",
-        "currency_iso_code": null
+        "currency_iso_code": "USD"
       },
       "description": "Invoice description",
       "direct_cost_attachment": {

--- a/erp_integration/erp_events_dictionary.md
+++ b/erp_integration/erp_events_dictionary.md
@@ -2342,7 +2342,7 @@ The ERP Integration is expected to check the state of the prime contract change 
       "currency_configuration": {
         "base_currency_iso_code": null,
         "currency_exchange_rate": "1.0",
-        "currency_iso_code": "USD"
+        "currency_iso_code": null
       },
       "description": "Invoice description",
       "direct_cost_attachment": {
@@ -2397,7 +2397,7 @@ The ERP Integration is expected to check the state of the prime contract change 
           "currency_configuration": {
             "base_currency_iso_code": null,
             "currency_exchange_rate": "1.0",
-            "currency_iso_code": "USD"
+            "currency_iso_code": null
           },
           "description": "Line item description",
           "direct_cost_id": "10000001",
@@ -2470,9 +2470,9 @@ There are no required actions. If necessary, the ERP Integration can clean up an
       "billed_amount": "1000.0",
       "created_at": "2025-06-01T10:00:00Z",
       "currency_configuration": {
-        "base_currency_iso_code": "USD",
+        "base_currency_iso_code": null,
         "currency_exchange_rate": "1.0",
-        "currency_iso_code": "USD"
+        "currency_iso_code": null
       },
       "description": "Invoice description",
       "direct_cost_attachment": {
@@ -2494,7 +2494,7 @@ There are no required actions. If necessary, the ERP Integration can clean up an
       "line_item_total": "1000.0",
       "paid_status": "unpaid",
       "payment_date": null,
-      "payment_due_date": null,
+      "payment_due_date": "2025-06-30T00:00:00Z",
       "projects": [
         {
           "id": 86,
@@ -2504,7 +2504,7 @@ There are no required actions. If necessary, the ERP Integration can clean up an
       "received_date": "2025-06-01",
       "review_status": "ready",
       "status": "approved",
-      "terms": null,
+      "terms": "NET 30",
       "updated_at": "2025-06-01T10:00:00Z",
       "uploaded_at": "2025-06-01T10:00:00Z",
       "uploaded_by": "user@example.com",

--- a/erp_integration/erp_events_dictionary.md
+++ b/erp_integration/erp_events_dictionary.md
@@ -15,7 +15,7 @@ The ERP Platform is events-driven. This means that, as an integrator, you will r
 - Exporting an unsynced record (e.g. **create_commitment**)
 - Staging records from the ERP System (e.g. **sync_sub_jobs**)
 
-The event notification payload can be found [here]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/webhooks_api.md %}).
+The event notification payload can be found [here]({{ site.url }}{{ site.baseurl }}{% link webhooks/webhooks_api.md %}).
 The main property to be aware of is **resource_id**, which is the ERP Request ID. As a system integrator, you are responsible for fetching event payloads from the [ERP Requests Show](https://developers.procore.com/reference/rest/v1/erp-requests#show-erp-request) endpoint using the **resource_id** provided above.
 
 ---
@@ -2332,53 +2332,67 @@ The ERP Integration is expected to check the state of the prime contract change 
   "request_name": "create_company_level_direct_cost",
   "request_data": {
     "request_detail_id": 1,
+    "company_id": 7,
     "direct_cost": {
-      "id": 25,
-      "accounting_date": "2025-06-11",
-      "billed_amount": "0.0",
-      "created_at": "2025-06-11T19:44:03Z",
+      "id": "171354581",
+      "accounting_date": "2026-05-01",
+      "ai_autofill": true,
+      "billed_amount": "920.13",
+      "created_at": "2026-05-11T15:09:39Z",
       "currency_configuration": {
         "base_currency_iso_code": null,
         "currency_exchange_rate": "1.0",
         "currency_iso_code": "USD"
       },
       "description": "Invoice description",
-      "direct_cost_attachment": null,
-      "direct_cost_date": "2025-06-13",
+      "direct_cost_attachment": {
+        "id": "6192570404",
+        "content_type": "application/pdf",
+        "created_at": "2026-05-11T15:09:39Z",
+        "name": "invoice.pdf",
+        "url": "https://storage.procore.com/...",
+        "uuid": "e053c20f079b42ac82bcc09a3ef919568cb5"
+      },
+      "direct_cost_date": "2026-05-01",
       "direct_cost_type": "invoice",
       "discount_date": null,
-      "employee": {
-        "id": 24,
-        "name": "Employee Name"
+      "employee": null,
+      "erp": {
+        "status": "exporting"
       },
       "invoice_number": "INV-001",
       "line_item_total": "1000.0",
-      "paid_status": null,
-      "payment_date": "2025-06-13",
-      "payment_due_date": "2025-06-30",
-      "received_date": "2025-06-13",
-      "review_status": "approved",
+      "paid_status": "unpaid",
+      "payment_date": null,
+      "payment_due_date": null,
+      "projects": [
+        {
+          "id": 86,
+          "name": "Test Project"
+        }
+      ],
+      "received_date": "2026-05-11",
+      "review_status": "ready",
       "status": "approved",
       "terms": null,
-      "updated_at": "2025-06-11T20:01:56Z",
-      "uploaded_at": "2025-06-05T18:48:24Z",
-      "uploaded_by": "User Name",
+      "updated_at": "2026-05-11T20:01:56Z",
+      "uploaded_at": "2026-05-11T15:09:39Z",
+      "uploaded_by": "user@example.com",
       "vendor": {
-        "id": 35,
+        "id": "18951792",
         "name": "Test Vendor",
         "origin_id": "vendor_origin_id",
-        "origin_code": null,
-        "origin_data": null
+        "origin_code": "V-00001",
+        "origin_data": "{}"
       },
       "origin_id": null,
       "origin_code": "INV-001",
       "origin_data": null,
       "line_items": [
         {
-          "id": 1,
+          "id": "385305686",
           "company": {
-            "id": 7,
-            "name": "Test Company"
+            "id": "7"
           },
           "currency_configuration": {
             "base_currency_iso_code": null,
@@ -2386,26 +2400,30 @@ The ERP Integration is expected to check the state of the prime contract change 
             "currency_iso_code": "USD"
           },
           "description": "Line item description",
-          "direct_cost_id": 25,
-          "extended_type": "manual",
+          "direct_cost_id": "171354581",
+          "extended_type": "calculated",
           "position": 1,
           "project": {
-            "id": 86,
+            "id": "86",
             "name": "Test Project"
           },
-          "quantity": "5.0",
-          "total_amount": "500.0",
-          "unit_cost": "100.0",
-          "uom": "ls",
-          "wbs_code": {
-            "id": 123
+          "quantity": "1.0",
+          "total_amount": "1000.0",
+          "unit_cost": "1000.0",
+          "uom": {
+            "name": "ea",
+            "read_only": false
           },
-          "cost_code_id": 456,
-          "cost_code_origin_id": "cost_code_origin_id",
-          "line_item_type_id": 789,
-          "line_item_type_origin_id": "line_item_type_origin_id",
+          "wbs_code": {
+            "id": "4806434576",
+            "flat_code": "03-10-50.S",
+            "description": "Concrete Coring"
+          },
           "job_origin_id": "project_origin_id",
-          "sub_job_id": null
+          "cost_code_id": 456,
+          "line_item_type_id": 789,
+          "cost_code_origin_id": "cost_code_origin_id",
+          "line_item_type_origin_id": "line_item_type_origin_id"
         }
       ]
     }
@@ -2422,7 +2440,7 @@ After the company level direct cost has been successfully exported to the ERP sy
   "request_name": "reset_company_level_direct_cost",
   "request_data": {
     "direct_cost": {
-      "id": 25
+      "id": "171354581"
     },
     "origin_id": "direct_cost_origin_id",
     "origin_code": "INV-001",
@@ -2444,8 +2462,56 @@ There are no required actions. If necessary, the ERP Integration can clean up an
   "request_name": "unlink_company_level_direct_cost",
   "request_data": {
     "request_detail_id": 1,
+    "company_id": 7,
     "direct_cost": {
-      "id": 25,
+      "id": "171354581",
+      "accounting_date": "2026-05-01",
+      "ai_autofill": true,
+      "billed_amount": "920.13",
+      "created_at": "2026-05-11T15:09:39Z",
+      "currency_configuration": {
+        "base_currency_iso_code": "USD",
+        "currency_exchange_rate": "1.0",
+        "currency_iso_code": "USD"
+      },
+      "description": "Invoice description",
+      "direct_cost_attachment": {
+        "id": "6192570404",
+        "content_type": "application/pdf",
+        "created_at": "2026-05-11T15:09:39Z",
+        "name": "invoice.pdf",
+        "url": "https://storage.procore.com/...",
+        "uuid": "e053c20f079b42ac82bcc09a3ef919568cb5"
+      },
+      "direct_cost_date": "2026-05-01",
+      "direct_cost_type": "invoice",
+      "discount_date": null,
+      "employee": null,
+      "erp": {
+        "status": "synced"
+      },
+      "invoice_number": "INV-001",
+      "line_item_total": "1000.0",
+      "paid_status": "unpaid",
+      "payment_date": null,
+      "payment_due_date": null,
+      "projects": [
+        {
+          "id": 86,
+          "name": "Test Project"
+        }
+      ],
+      "received_date": "2026-05-11",
+      "review_status": "ready",
+      "status": "approved",
+      "terms": null,
+      "updated_at": "2026-05-11T20:01:56Z",
+      "uploaded_at": "2026-05-11T15:09:39Z",
+      "uploaded_by": "user@example.com",
+      "vendor": {
+        "id": "18951792",
+        "name": "Test Vendor"
+      },
       "origin_id": "direct_cost_origin_id",
       "origin_code": "INV-001",
       "origin_data": null

--- a/erp_integration/erp_events_dictionary.md
+++ b/erp_integration/erp_events_dictionary.md
@@ -2315,6 +2315,149 @@ The ERP Integration is expected to check the state of the prime contract change 
 
 ---
 
+## Company Level Direct Costs
+
+| **Name**                                                                        | **Super User** | **Action Required** | **Occurs When**                                                                                             |
+|---------------------------------------------------------------------------------|----------------|---------------------|-------------------------------------------------------------------------------------------------------------|
+| [**create_company_level_direct_cost**](#create_company_level_direct_cost)       | No             | Yes                 | A user exports a company level direct cost from the ERP Tab in Procore.                                     |
+| [**reset_company_level_direct_cost**](#reset_company_level_direct_cost)         | Yes            | No                  | An ERP support representative, at the request of the customer, uses Super User access to reset a synced company level direct cost. |
+| [**unlink_company_level_direct_cost**](#unlink_company_level_direct_cost)       | No             | Yes                 | A user attempts to unlink a company level direct cost in the ERP Integration tool.                          |
+
+<br>
+
+### create_company_level_direct_cost
+**Event Payload:**
+```
+{
+  "request_name": "create_company_level_direct_cost",
+  "request_data": {
+    "request_detail_id": 1,
+    "direct_cost": {
+      "id": 25,
+      "accounting_date": "2025-06-11",
+      "billed_amount": "0.0",
+      "created_at": "2025-06-11T19:44:03Z",
+      "currency_configuration": {
+        "base_currency_iso_code": null,
+        "currency_exchange_rate": "1.0",
+        "currency_iso_code": "USD"
+      },
+      "description": "Invoice description",
+      "direct_cost_attachment": null,
+      "direct_cost_date": "2025-06-13",
+      "direct_cost_type": "invoice",
+      "discount_date": null,
+      "employee": {
+        "id": 24,
+        "name": "Employee Name"
+      },
+      "invoice_number": "INV-001",
+      "line_item_total": "1000.0",
+      "paid_status": null,
+      "payment_date": "2025-06-13",
+      "payment_due_date": "2025-06-30",
+      "received_date": "2025-06-13",
+      "review_status": "approved",
+      "status": "approved",
+      "terms": null,
+      "updated_at": "2025-06-11T20:01:56Z",
+      "uploaded_at": "2025-06-05T18:48:24Z",
+      "uploaded_by": "User Name",
+      "vendor": {
+        "id": 35,
+        "name": "Test Vendor",
+        "origin_id": "vendor_origin_id",
+        "origin_code": null,
+        "origin_data": null
+      },
+      "origin_id": null,
+      "origin_code": "INV-001",
+      "origin_data": null,
+      "line_items": [
+        {
+          "id": 1,
+          "company": {
+            "id": 7,
+            "name": "Test Company"
+          },
+          "currency_configuration": {
+            "base_currency_iso_code": null,
+            "currency_exchange_rate": "1.0",
+            "currency_iso_code": "USD"
+          },
+          "description": "Line item description",
+          "direct_cost_id": 25,
+          "extended_type": "manual",
+          "position": 1,
+          "project": {
+            "id": 86,
+            "name": "Test Project"
+          },
+          "quantity": "5.0",
+          "total_amount": "500.0",
+          "unit_cost": "100.0",
+          "uom": "ls",
+          "wbs_code": {
+            "id": 123
+          },
+          "cost_code_id": 456,
+          "cost_code_origin_id": "cost_code_origin_id",
+          "line_item_type_id": 789,
+          "line_item_type_origin_id": "line_item_type_origin_id",
+          "job_origin_id": "project_origin_id",
+          "sub_job_id": null
+        }
+      ]
+    }
+  }
+}
+```
+**Required Actions:**
+After the company level direct cost has been successfully exported to the ERP system, the integrator must send back its third-party **origin_id** to Procore to mark the direct cost as synced, via the [ERP External Data Sync](https://developers.procore.com/reference/rest/v1/erp-external-data?version=1.0#sync-external-data) endpoint using **item_type=company_level_direct_cost** and **item_id** equal to the direct cost's **id**. Integrators also need to close out the **request_detail_id** associated with the export request, using the [ERP Request Details](https://developers.procore.com/reference/rest/v1/erp-request-details) endpoints. Any error messages included when closing out the request detail will be displayed to the user in the ERP Tab in Procore.
+
+### reset_company_level_direct_cost
+**Event Payload:**
+```
+{
+  "request_name": "reset_company_level_direct_cost",
+  "request_data": {
+    "direct_cost": {
+      "id": 25
+    },
+    "origin_id": "direct_cost_origin_id",
+    "origin_code": "INV-001",
+    "origin_data": null,
+    "reset_override": false
+  }
+}
+```
+**Additional Info:**
+This will return the company level direct cost to an unsynced state in Procore.
+
+**Required Actions:**
+There are no required actions. If necessary, the ERP Integration can clean up any related cached data for the direct cost.
+
+### unlink_company_level_direct_cost
+**Event Payload:**
+```
+{
+  "request_name": "unlink_company_level_direct_cost",
+  "request_data": {
+    "request_detail_id": 1,
+    "direct_cost": {
+      "id": 25,
+      "origin_id": "direct_cost_origin_id",
+      "origin_code": "INV-001",
+      "origin_data": null
+    }
+  }
+}
+```
+**Required Actions:**
+The ERP Integration is expected to check the state of the company level direct cost. If the direct cost is in a deleted state (e.g. deleted, archived, etc.) in the ERP system, it should be marked as unsynced in Procore via the [ERP External Data Sync](https://developers.procore.com/reference/rest/v1/erp-external-data?version=1.0#sync-external-data) endpoint using **item_type=company_level_direct_cost**. The request detail should then be closed out, optionally with error messages if the direct cost failed to unlink, using the [ERP Request Details](https://developers.procore.com/reference/rest/v1/erp-request-details) endpoints.
+
+---
+
 ## ERP Metadata
 
 | **Name**                            | **Super User** | **Action Required** | **Occurs When**                                                                                           |

--- a/erp_integration/erp_metadata_details.md
+++ b/erp_integration/erp_metadata_details.md
@@ -1756,6 +1756,80 @@ The Company Level Direct Costs metadata supports exporting company level direct 
             "fields": {}
           }
         }
+      },
+      "company_level_direct_costs": {
+        "enabled": true,
+        "configs": {
+          "export": {
+            "enabled": true
+          },
+          "unlink": {
+            "enabled": true
+          }
+        },
+        "tab": {
+          "enabled": true,
+          "columns": {
+            "code": {
+              "enabled": true,
+              "text": "ERP ID"
+            }
+          }
+        },
+        "rules": {
+          "export": {
+            "warning_message": {
+              "enabled": false,
+              "message": ""
+            },
+            "fields": {
+              "invoice_number": {
+                "enabled": true,
+                "validation": {
+                  "present": {
+                    "enabled": true,
+                    "message": "Invoice number can't be blank."
+                  }
+                }
+              },
+              "billing_date": {
+                "enabled": true,
+                "validation": {
+                  "present": {
+                    "enabled": true,
+                    "message": "Billing date can't be blank."
+                  }
+                }
+              },
+              "origin_code": {
+                "enabled": true,
+                "validation": {
+                  "present": {
+                    "enabled": true,
+                    "message": "Invoice ID can't be blank."
+                  },
+                  "max_length": {
+                    "enabled": true,
+                    "length": 15,
+                    "message": "Invoice ID cannot be more than %{length} characters."
+                  }
+                }
+              }
+            }
+          },
+          "save": {
+            "fields": {
+              "invoice_number": {
+                "validation": {
+                  "max_length": {
+                    "enabled": true,
+                    "length": 15
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/erp_integration/erp_metadata_details.md
+++ b/erp_integration/erp_metadata_details.md
@@ -74,6 +74,7 @@ Procore currently supports the following entities:
 - job_cost_transactions
 - commitments
 - commitment_change_orders
+- company_level_direct_costs
 - requisitions
 - payment_applications
 - prime_contracts
@@ -718,6 +719,81 @@ The Payment Application metadata does not contain any custom configurations. Pay
     },
     "save": {
       "fields": {}
+    }
+  }
+}
+```
+
+## Company Level Direct Costs Metadata Structure
+
+The Company Level Direct Costs metadata supports exporting company level direct costs from Procore to the ERP system and unlinking previously synced direct costs.
+
+- **export** - Enabling this configuration allows Procore company level direct costs to be exported to the ERP system.
+- **unlink** - This configuration allows a user to unlink a synced company level direct cost in the ERP tab. When a direct cost is unlinked, a Webhook event is delivered to the ERP Integration. The ERP Integration can choose to perform any cleanup related to the unlinked direct cost.
+
+```
+"company_level_direct_costs": {
+  "enabled": true,
+  "configs": {
+    "export": {
+      "enabled": true
+    },
+    "unlink": {
+      "enabled": true
+    }
+  },
+  "tab": {
+    "enabled": true,
+    "columns": {
+      "code": {
+        "enabled": true,
+        "text": "ERP ID"
+      }
+    }
+  },
+  "rules": {
+    "export": {
+      "warning_message": {
+        "enabled": false,
+        "message": ""
+      },
+      "fields": {
+        "invoice_number": {
+          "enabled": true,
+          "validation": {
+            "present": {
+              "enabled": true,
+              "message": "Invoice number can't be blank."
+            }
+          }
+        },
+        "origin_code": {
+          "enabled": true,
+          "validation": {
+            "present": {
+              "enabled": true,
+              "message": "Invoice ID can't be blank."
+            },
+            "max_length": {
+              "enabled": true,
+              "length": 15,
+              "message": "Invoice ID cannot be more than %{length} characters."
+            }
+          }
+        }
+      }
+    },
+    "save": {
+      "fields": {
+        "invoice_number": {
+          "validation": {
+            "max_length": {
+              "enabled": true,
+              "length": 15
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/erp_integration/erp_metadata_details.md
+++ b/erp_integration/erp_metadata_details.md
@@ -767,6 +767,15 @@ The Company Level Direct Costs metadata supports exporting company level direct 
             }
           }
         },
+        "billing_date": {
+          "enabled": true,
+          "validation": {
+            "present": {
+              "enabled": true,
+              "message": "Billing date can't be blank."
+            }
+          }
+        },
         "origin_code": {
           "enabled": true,
           "validation": {


### PR DESCRIPTION
Add Company Level Direct Costs to the ERP Events Dictionary and ERP Metadata Developer Guide, enabling internal and external developers to build integrations for this entity type.

- erp_events_dictionary.md: new section with create, reset, and unlink event payloads and required actions
- erp_metadata_details.md: added company_level_direct_costs to the supported entities list and added a full metadata structure example