### PR TITLE
AGX-6522: Hide MCP Integration docs from navigation and site

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -207,10 +207,10 @@
     - title: Novorender BIM Web Viewer (Experimental)
       url: /novolib-bim-web-viewer
 
-- title: MCP Integration
-  items:
-    - title: Procore AI Edge MCP Setup
-      url: /procore-ai-edge-mcp-setup
+# - title: MCP Integration
+#   items:
+#     - title: Procore AI Edge MCP Setup
+#       url: /procore-ai-edge-mcp-setup
 
 - title: Announcements
   items:

--- a/mcp/procore_ai_edge_mcp_setup.md
+++ b/mcp/procore_ai_edge_mcp_setup.md
@@ -1,4 +1,4 @@
----
+<!-- ---
 permalink: /procore-ai-edge-mcp-setup
 title: Procore AI Edge MCP Setup
 layout: default
@@ -231,4 +231,4 @@ If neither resolves, project-scoped calls fail with a clear error. If you don't 
 | `whoami` returns a network error | Wrong server URL or network access issue | Confirm you're using the correct zone endpoint |
 | `procore_read` fails with "no company id resolved" | Missing Procore routing | Add `procore-company-id` to headers or pass `companyId` on the call |
 | Tools not listed in Cursor | `mcp.json` syntax error or wrong URL | Validate JSON and reload Cursor's MCP integration |
-| Claude Code does not pick up config changes | Config is read at session start | Restart the Claude Code session |
+| Claude Code does not pick up config changes | Config is read at session start | Restart the Claude Code session | -->


### PR DESCRIPTION
Comments out the MCP Integration nav entry and wraps the Procore AI Edge MCP Setup page content so it no longer renders on the site.