### PR TITLE
Explicitly register redirects plugin.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 group :jekyll_plugins do
   gem "github-pages", "~> 214"
   gem "jekyll-feed", "~> 0.12"
+  gem "jekyll-redirect-from", "~> 0.16"
 end
 
 gem "minima", "~> 2.5"

--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,7 @@ url: "https://developers.procore.com" # the base hostname & protocol for your si
 theme: minima
 plugins:
   - jekyll-feed
+  - jekyll-redirect-from
 
 # Exclude from processing.
 # The following items will not be processed, by default.


### PR DESCRIPTION
Explicitly register `jekyll-redirect-from` plugin to allow github pages redirects.