### PR TITLE
docs(DOCINT-1749): standardize PDM documentation links

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -240,11 +240,11 @@
 
 # - title: Document Management Integration
 #   items:
-#     - title: Getting Started
+#     - title: Overview
 #       url: /document-management-intro
-#     - title: Technical Guide
-#       url: /document-management-technical-guide
 #     - title: API Endpoints
 #       url: /document-management-api-endpoints
+#     - title: Technical Guide
+#       url: /document-management-technical-guide
 #     - title: Metadata Details
 #       url: /document-management-metadata-details

--- a/document_management_integration/document_management_api_endpoints.md
+++ b/document_management_integration/document_management_api_endpoints.md
@@ -6,7 +6,19 @@ section_title: Document Management Integration
 
 ---
 
-## Document Management API Endpoints
+This page provides a reference of all available endpoints for the Procore Document Management V2 API.
+
+***
+## Related Documentation
+
+- [Overview]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_intro.md %})
+- **API Endpoints** (this page)
+- [Technical Guide]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_technical_guide.md %})
+- [Metadata Details]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_metadata_details.md %})
+
+***
+
+## Available Endpoints
 
 | Name | Action | Endpoint URI | Description |
 | --- | --- | --- | --- |
@@ -18,3 +30,10 @@ section_title: Document Management Integration
 | [List Project Upload Requirements](https://developers.procore.com/reference/rest/project-upload-requirements?version=2.0#list-project-upload-requirements) | GET | /rest/v2.0/companies/{company_id}/projects/{project_id}/document_management/upload_requirements | Returns a list of Upload Requirements for the Project. |
 | [List Project Metadata Values](https://developers.procore.com/reference/rest/project-metadata-values?version=2.0#list-project-metadata-values) | GET | /rest/v2.0/companies/{company_id}/projects/{project_id}/document_management/fields/{field_id_or_name}/values | Returns a list of Metadata Values for the specified field. |
 | [Bulk Create Document Revisions](https://developers.procore.com/reference/rest/document-revisions?version=2.0#create-document-revisions-v2) | POST | /rest/v2.0/companies/{company_id}/projects/{project_id}/document_management/document_revisions | Creates one or more document revisions from document uploads. |
+
+## See Also
+
+- [Choose an Authentication Method]({{ site.url }}{{ site.baseurl }}{% link oauth/oauth_choose_grant_type.md %})
+- [Unified File Upload API]({{ site.url }}{{ site.baseurl }}{% link tutorials/tutorial_unified_uploads.md %})
+- [Rate Limiting]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/rate_limiting.md %})
+- [Procore Support: Document Management](https://v2.support.procore.com/product-manuals/document-management-project)

--- a/document_management_integration/document_management_intro.md
+++ b/document_management_integration/document_management_intro.md
@@ -11,6 +11,16 @@ section_title: Document Management Integration
 The Procore Document Management (PDM) system provides a platform for integrators to programmatically sync documents from external systems into Procore projects.
 Before you begin working with the various Document Management API endpoints, we recommend familiarizing yourself with the core concepts, architecture, and workflows outlined in this guide.
 
+***
+## Related Documentation
+
+- **Overview** (this page)
+- [API Endpoints]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_api_endpoints.md %})
+- [Technical Guide]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_technical_guide.md %})
+- [Metadata Details]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_metadata_details.md %})
+
+***
+
 ### Things to Consider
 
 To get started with the Document Management API, ensure you have completed these steps:
@@ -125,7 +135,8 @@ Consider the following recommendations when building your integration:
 - **API Rate Limits** - Usage of Procore's API is subject to rate limits. The rate limit resets every hour. See [Rate Limiting]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/rate_limiting.md %}) to learn how to reduce the possibility of exceeding the rate limit.
 
 ## See Also
-- [Document Management APIs]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_api_endpoints.md %})  
-- [Document Management Metadata Details]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_metadata_details.md %})  
-- [Document Management Technical Guide]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_technical_guide.md %})   
+
+- [Choose an Authentication Method]({{ site.url }}{{ site.baseurl }}{% link oauth/oauth_choose_grant_type.md %})
 - [Unified File Upload API]({{ site.url }}{{ site.baseurl }}{% link tutorials/tutorial_unified_uploads.md %})
+- [Rate Limiting]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/rate_limiting.md %})
+- [Procore Support: Document Management](https://v2.support.procore.com/product-manuals/document-management-project)

--- a/document_management_integration/document_management_metadata_details.md
+++ b/document_management_integration/document_management_metadata_details.md
@@ -11,6 +11,15 @@ Document Metadata is a set of attributes that provide information about a docume
 This reference describes the metadata structure returned by **Document Upload** and **Document Revision** API endpoints.
 
 ***
+## Related Documentation
+
+- [Overview]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_intro.md %})
+- [API Endpoints]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_api_endpoints.md %})
+- [Technical Guide]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_technical_guide.md %})
+- **Metadata Details** (this page)
+
+***
+
 <details>
 <summary class="collapseListTierOne">Overview of document metadata fields</summary>
 <pre><code>{
@@ -1053,3 +1062,10 @@ Document Management can process 3D model files (BIM/Building Information Models)
 }
 </code></pre>
 </details>
+
+## See Also
+
+- [Choose an Authentication Method]({{ site.url }}{{ site.baseurl }}{% link oauth/oauth_choose_grant_type.md %})
+- [Unified File Upload API]({{ site.url }}{{ site.baseurl }}{% link tutorials/tutorial_unified_uploads.md %})
+- [Rate Limiting]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/rate_limiting.md %})
+- [Procore Support: Document Management](https://v2.support.procore.com/product-manuals/document-management-project)

--- a/document_management_integration/document_management_technical_guide.md
+++ b/document_management_integration/document_management_technical_guide.md
@@ -8,9 +8,17 @@ section_title: Document Management Integration
 
 This guide walks you through the complete API workflow for uploading documents, enriching them with metadata, and submitting them as document revisions using the Procore Document Management V2 API.
 
-Before starting, review the [Document Management Integration Overview]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_intro.md %}) for prerequisites, core concepts, and best practices. Your service account will specifically need Upload New Files and Submit New Files permissions enabled in the project's Document Management tool. For a reference of all available endpoints, see [Document Management API Endpoints]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_api_endpoints.md %}).
+***
+## Related Documentation
 
-> **Important:** We recommend developing and testing your integration against the [Procore Developer Sandbox](https://developers.procore.com/documentation/development-environments) before pointing your integration at a live project. The sandbox environment is a safe place to iterate on requests and validate responses without risk to real project data.
+- [Overview]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_intro.md %})
+- [API Endpoints]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_api_endpoints.md %})
+- **Technical Guide** (this page)
+- [Metadata Details]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_metadata_details.md %})
+
+***
+
+> **Important:** Your service account will need Upload New Files and Submit New Files permissions enabled in the project's Document Management tool. We also recommend developing and testing your integration against the [Procore Developer Sandbox](https://developers.procore.com/documentation/development-environments) before pointing your integration at a live project. The sandbox environment is a safe place to iterate on requests and validate responses without risk to real project data.
 
 ### Base URL
 
@@ -694,7 +702,7 @@ The following errors apply to all Document Management API endpoints. It is recom
 
 | HTTP Status | Reason Code | Description | Resolution |
 | --- | --- | --- | --- |
-| 401 | `INVALID_TOKEN` | Authentication token is missing, invalid, or expired. | Provide a valid OAuth 2.0 access token. See [Authentication]({{ site.url }}{{ site.baseurl }}{% link oauth/oauth_introduction.md %}) for details. |
+| 401 | `INVALID_TOKEN` | Authentication token is missing, invalid, or expired. | Provide a valid OAuth 2.0 access token. See [Authentication]({{ site.url }}{{ site.baseurl }}{% link oauth/oauth_choose_grant_type.md %}) for details. |
 | 403 | `FORBIDDEN` | The service account lacks permissions for the requested action. | Ensure the service account has the "Upload New Files" and "Submit New Files" permissions in the project's Document Management tool. |
 | 429 | `TOO_MANY_REQUESTS` | The integration has exceeded Procore's API rate limit. | Inspect the `Retry-After` header in the response, pause your upload loop, and retry after the specified number of seconds. See [Rate Limiting]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/rate_limiting.md %}) for details. |
 | 500 | `INTERNAL_SERVER_ERROR` | The server encountered an unexpected error. | Retry the request after a short delay. |
@@ -995,11 +1003,9 @@ Check the `failures` array even on a 201 response. If empty, the document is now
 
 ---
 
-## Additional Resources
+## See Also
 
-- [Document Management Integration Overview]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_intro.md %})
-- [Document Management API Endpoints]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_api_endpoints.md %})
-- [Document Management Metadata Details]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_metadata_details.md %})
-- [Introduction to OAuth 2.0]({{ site.url }}{{ site.baseurl }}{% link oauth/oauth_introduction.md %})
+- [Choose an Authentication Method]({{ site.url }}{{ site.baseurl }}{% link oauth/oauth_choose_grant_type.md %})
+- [Unified File Upload API]({{ site.url }}{{ site.baseurl }}{% link tutorials/tutorial_unified_uploads.md %})
 - [Rate Limiting]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/rate_limiting.md %})
 - [Procore Support: Document Management](https://v2.support.procore.com/product-manuals/document-management-project)


### PR DESCRIPTION
# [Jira: DOCINT-1749](https://procoretech.atlassian.net/browse/DOCINT-1749)

## Summary

Standardizes cross-page navigation across the four Document Management Integration (PDM) guide pages and fixes dead authentication links.

- Adds a consistent, rule-separated **Related Documentation** index near the top of each PDM page (Overview, API Endpoints, Technical Guide, Metadata Details), with the current page marked in bold so readers can orient and jump between sibling pages regardless of where they land.
- Standardizes the bottom **See Also** external resources list across all four pages (Choose an Authentication Method, Unified File Upload API, Rate Limiting, Procore Support: Document Management), replacing the inconsistent "Additional Resources"/intra-page link lists.
- Fixes dead `oauth_introduction` links (now redirect-only) to point at `oauth_choose_grant_type`, including the `INVALID_TOKEN` resolution in the Technical Guide error reference.
- Minor copy edits: adds a one-line intro to the API Endpoints page and tightens the Technical Guide prerequisites note.

## Files Changed

- `document_management_integration/document_management_intro.md`
- `document_management_integration/document_management_api_endpoints.md`
- `document_management_integration/document_management_technical_guide.md`
- `document_management_integration/document_management_metadata_details.md`

## Test Plan

- [x] `bundle exec jekyll serve` builds with no errors and all `{% link %}` references resolve.
- [x] Verify the Related Documentation index renders on each page with the correct current-page marked in bold.
- [x] Confirm all See Also links (including the updated OAuth link) navigate correctly.
