### PR TITLE
docs(DOCINT-1806): enable Document Management and Unified Uploads navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -131,8 +131,8 @@
       url: /attachments
     - title: Direct File Uploads
       url: /tutorial-uploads
-    # - title: Unified Uploads
-    #   url: /tutorial-unified-file-uploads //disabled until GA release
+    - title: Unified Uploads
+      url: /tutorial-unified-file-uploads
     - title: Secure File Access
       url: /secure-file-access-tips
     - title: Drawings
@@ -238,13 +238,13 @@
 #     - title: Staged Records
 #       url: /erp-staged-records-details
 
-# - title: Document Management Integration
-#   items:
-#     - title: Overview
-#       url: /document-management-intro
-#     - title: API Endpoints
-#       url: /document-management-api-endpoints
-#     - title: Technical Guide
-#       url: /document-management-technical-guide
-#     - title: Metadata Details
-#       url: /document-management-metadata-details
+- title: Document Management Integration
+  items:
+    - title: Overview
+      url: /document-management-intro
+    - title: API Endpoints
+      url: /document-management-api-endpoints
+    - title: Technical Guide
+      url: /document-management-technical-guide
+    - title: Metadata Details
+      url: /document-management-metadata-details

--- a/document_management_integration/document_management_access.md
+++ b/document_management_integration/document_management_access.md
@@ -1,9 +1,0 @@
----
-permalink: /document-management-access-required
-title: Document Management Documentation
-layout: default
-section_title: Document Management Integration
-
----
-
-Access to Document Management documentation is only available for a select number of Procore partners and clients.


### PR DESCRIPTION
### Ticket: https://procoretech.atlassian.net/browse/DOCINT-1806

## Summary
Enable discoverability of already-existing docs by uncommenting their navigation entries in `_data/navigation.yml`. No new content — navigation enablement only.

- Enable the **Document Management Integration** nav section (Overview, API Endpoints, Technical Guide, Metadata Details).
- Enable the **Unified Uploads** tutorial entry under "Product Guides: Documents & Files", removing the "disabled until GA release" gating.
- Remove the `document_management_access.md` allow-list placeholder page (no longer needed now that the docs are becoming public).

## Testing
- Verified all linked `url` permalinks resolve to existing pages (4 DM pages + `tutorial_unified_uploads.md`).
- Confirmed no duplicate nav entries introduced.

<img width="1705" height="1307" alt="Screenshot 2026-07-14 at 5 58 50 PM" src="https://github.com/user-attachments/assets/4dce9e40-2ac3-42c5-ae2c-c4cc2ed499bf" />
<img width="1696" height="1316" alt="Screenshot 2026-07-14 at 5 58 29 PM" src="https://github.com/user-attachments/assets/f1c89131-5c02-4cc7-bd0a-99ace9f89345" />


## Notes
Depends on [DOCINT-1779](https://procoretech.atlassian.net/browse/DOCINT-1779) (APIs moving to public visibility).
- https://github.com/procore/document-service/pull/6711
- https://github.com/procore/file-upload-service/pull/728


[DOCINT-1779]: https://procoretech.atlassian.net/browse/DOCINT-1779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ