### PR TITLE
DOCINT-1847: Fix incorrect field types in Metadata Details docs

### DIFF
--- a/document_management_integration/document_management_metadata_details.md
+++ b/document_management_integration/document_management_metadata_details.md
@@ -553,8 +553,8 @@ Document Management can process 3D model files (BIM/Building Information Models)
       "type": "lov_entry",
       "values": [],
       "label_source": "NONE",
-      "label": "Level",
-      "description": "The level of a building or structure"
+      "label": "Classification",
+      "description": "The classification of the document revision"
     },
     {
       "id": "58IC8WRCV30EE1URJHN19TNY1",

--- a/document_management_integration/document_management_metadata_details.md
+++ b/document_management_integration/document_management_metadata_details.md
@@ -150,7 +150,7 @@ Standard fields available across all projects for document organization and clas
 | **authored_by** | reference | The person who created the document. Defaults to uploader if not provided. |
 | **classification** | lov_entry | Subtype of a document. |
 | **date_authored** | timestamp | Date the document was created. Auto-populated from document content when detected, but can be edited via API. |
-| **description** | string | A brief title for the document. |
+| **description** | rich_text | A brief title for the document. |
 | **discipline** | lov_entry | Discipline associated with the document. |
 | **document_stage** | lov_entry | The associated stage of the document lifecycle. |
 | **file_locked** | boolean | Whether the file is locked for editing. Can be toggled via API. |
@@ -184,7 +184,7 @@ System-generated fields are automatically populated and cannot be directly modif
 | **download_url** | string | URL to download the file. | Generated on request |
 | **file_size** | string | Size of file in bytes. | Set on file upload |
 | **file_key** | string | File upload ID returned by the file upload API. | Set on file upload |
-| **format** | string | File format/type derived from MIME type. | Set on file upload |
+| **format** | lov_entry | File format/type derived from MIME type. | Set on file upload |
 | **id** | string | Unique identifier assigned at upload creation. Use this ID for update operations. | Set at creation |
 | **integration_statuses** | object | Status of active integrations. | Set at creation, updates during processing |
 | **integrations** | object | Detailed integration information. | Set at creation, updates during processing |


### PR DESCRIPTION
## Jira

https://procoretech.atlassian.net/browse/DOCINT-1847

## Summary

The published [Document Management Metadata Details](https://developers.procore.com/documentation/document-management-metadata-details) page had two field type inaccuracies when compared against the `document-service` source of truth (`project-fields.seed.ts`). This PR corrects both, fixes a related mislabeled example field discovered during verification, and confirms the rest of the `document_management_integration` docs folder is consistent with the source of truth.

## Changes

File: `document_management_integration/document_management_metadata_details.md`

| Field | Location | Before | After | Why |
|---|---|---|---|---|
| `description` | Standard Metadata Fields table | type: `string` | type: `rich_text` | Matches `FieldType.RICH_TEXT` in seed data, and the example API response already shown on the same page (`"name": "description", "type": "rich_text"`). |
| `format` | System Fields table | type: `string` | type: `lov_entry` | Matches `FieldType.LOV_ENTRY` in seed data, and the example API response already shown on the same page, which includes a full LOV-style `values` object (`id`, `code`, `label`, `active`, `tags`) — a shape that only applies to `lov_entry`. |
| `classification` | Example Document Upload API response (`fields[]` entry) | `"label": "Level"`, `"description": "The level of a building or structure"` | `"label": "Classification"`, `"description": "The classification of the document revision"` | Found while auditing the rest of the page — this entry had the label/description of an unrelated "Level" field (copy-paste artifact). Its `type` (`lov_entry`) was already correct. Corrected to match `project-fields.seed.ts`. |

## Verification

- Re-checked every other reference to `description` and `format` on the page (the "DIRECT FIELDS" payload table and the example Document Upload API response JSON block) — both already documented `rich_text`/`lov_entry` correctly, so the two table rows were the only stale type references.
- Audited the entire `document_management_integration/` folder (all 4 files) field-by-field against `document-service`'s `project-fields.seed.ts`, `onboarded-data/project-fields.ts`, and the `FieldType`/`DefaultFieldName` enums in `common/constants.ts`. No other field-type inconsistencies found; the `classification` label/description above was the only additional issue surfaced.

## Testing performed

Documentation-only change (no code/build changes). Verified via read-through of the rendered Markdown tables and cross-referencing every field name/type pair on the page and across the folder against the backend source of truth.

---
Developed with AI Orchestration