### PR TITLE
Agx 7149 link accessibility

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -29,6 +29,8 @@
       url: /tutorial-mpz
     - title: Procore's Federal Environment
       url: /federal-zone-overview
+    - title: API Lifecycle
+      url: /rest-api-lifecycle
     - title: API Usage Guidelines
       url: /api-usage-guidelines
     - title: API Security Overview
@@ -66,8 +68,6 @@
       url: /install-version-sandbox
     - title: Promote a Version to Production
       url: /building-apps-promote-manifest
-    - title: Manage App Collaborators
-      url: /building-apps-manage-collabs
     # - title: Creating an App Manifest - NEEDED FOR REDIRECT
     #   url: /building-apps-define-manifest
     # - title: App Versioning and Update Notification - NEEDED FOR REDIRECT
@@ -80,6 +80,21 @@
     #   url: /building-apps-metrics - Redirect
     # - title: Maximizing Conversation Rates
     #   url: /building-apps-maximizing-conversion-rates - Redirect
+
+- title: Manage & Monitor Your App
+  items:
+    - title: Integration Health
+      url: /integration-health
+    - title: API Call Activity Report
+      url: /api-activity-export
+    - title: Troubleshooting
+      url: /troubleshooting
+    - title: Request a Rate Limit Increase
+      url: /rate-limit-increase
+    - title: Manage App Collaborators
+      url: /building-apps-manage-collabs
+    - title: OAuth Credentials Management
+      url: /oauth-keys
 
 - title: Marketplace & Partnership
   items:
@@ -160,75 +175,18 @@
     - title: Workflows (Legacy)
       url: /tutorial-workflows
 
-- title: Reference
+- title: "Integration Guides: Document Management"
   items:
-    - title: OAuth Credentials Management
-      url: /oauth-keys
-    - title: OAuth 2.0 Authorization Code Grant
-      url: /oauth-auth-grant-flow
-    - title: OAuth 2.0 Client Credentials Grant
-      url: /oauth-client-credentials
-    - title: Authentication Endpoints
-      url: /oauth-endpoints
-    - title: REST API Overview
-      url: /rest-api-overview
-    - title: API Lifecycle
-      url: /rest-api-lifecycle
-    - title: RESTful API Concepts
-      url: /restful-api-concepts
-    - title: Pagination
-      url: /pagination
-    - title: Filtering & Sorting
-      url: /filtering-on-list-actions
-    - title: URL Parameter Interpolation
-      url: /building-apps-url-parameter-interpolation
-    - title: Side Panel View Keys
-      url: /side-panel-view-keys
-    - title: Dates, Times & Time Zones
-      url: /date-time
-    - title: Country Codes
-      url: /country-codes
-    - title: Sync Actions
-      url: /using-sync-actions
-    - title: Error Code Reference
-      url: /error-reference
-    - title: Troubleshooting
-      url: /troubleshooting
-    - title: Integration Health
-      url: /integration-health
-    - title: API Call Activity Report
-      url: /api-activity-export
+    - title: Overview
+      url: /document-management-intro
+    # - title: API Endpoints
+    #   url: /document-management-api-endpoints - Retired 2026-08-17, re-hosted endpoint data; see the REST reference. Needed for Redirect
+    - title: Technical Guide
+      url: /document-management-technical-guide
+    - title: Metadata Details
+      url: /document-management-metadata-details
 
-- title: Example Apps & SDKs
-  items:
-    - title: SDKs & Sample Applications
-      url: /sdk
-    - title: Procore Iframe Helper
-      url: /procore-iframe-helper
-    - title: BIM Web Viewer API
-      url: /bim-web-viewer
-    - title: BIM Web Viewer Demo
-      url: /bim-web-viewer-demo
-    - title: Novorender BIM Web Viewer (Experimental)
-      url: /novolib-bim-web-viewer
-
-# - title: MCP Integration
-#   items:
-#     - title: Procore AI Edge MCP Setup
-#       url: /procore-ai-edge-mcp-setup
-
-- title: Announcements
-  items:
-    - title: Changelog
-      url: /overview
-    - title: Agentic APIs
-      url: /agentic-apis
-    - title: "Deprecation: Project Directory Update Webhooks"
-      url: /webhook-fanout-migration
-    - title: New REST V2 Version
-      url: /new-rest-v2-version
-
-# - title: ERP Integration
+# - title: "Integration Guides: ERP"
 #   items:
 #     - title: Getting Started
 #       url: /erp-intro
@@ -243,13 +201,60 @@
 #     - title: Staged Records
 #       url: /erp-staged-records-details
 
-- title: Document Management Integration
+# - title: "Integration Guides: MCP"
+#   items:
+#     - title: Procore AI Edge MCP Setup
+#       url: /procore-ai-edge-mcp-setup
+
+- title: Reference
   items:
-    - title: Overview
-      url: /document-management-intro
-    - title: API Endpoints
-      url: /document-management-api-endpoints
-    - title: Technical Guide
-      url: /document-management-technical-guide
-    - title: Metadata Details
-      url: /document-management-metadata-details
+    - title: OAuth 2.0 Authorization Code Grant
+      url: /oauth-auth-grant-flow
+    - title: OAuth 2.0 Client Credentials Grant
+      url: /oauth-client-credentials
+    - title: Authentication Endpoints
+      url: /oauth-endpoints
+    - title: REST API Overview
+      url: /rest-api-overview
+    - title: Request & Response Format
+      url: /restful-api-concepts
+    - title: Pagination
+      url: /pagination
+    - title: Filtering & Sorting
+      url: /filtering-on-list-actions
+    - title: URL Parameter Interpolation
+      url: /building-apps-url-parameter-interpolation
+    - title: Side Panel View Keys
+      url: /side-panel-view-keys
+    - title: Dates, Times & Codes
+      url: /date-time
+    # - title: Country Codes
+    #   url: /country-codes - Retired 2026-08-17, merged into /date-time. Needed for Redirect
+    - title: Sync Actions
+      url: /using-sync-actions
+    - title: Error Code Reference
+      url: /error-reference
+
+- title: Example Apps & SDKs
+  items:
+    # - title: SDKs & Sample Applications - Needed for Redirect
+    #   url: /sdk - Needed for Redirect
+    - title: Procore Iframe Helper
+      url: /procore-iframe-helper
+    - title: BIM Web Viewer API
+      url: /bim-web-viewer
+    - title: BIM Web Viewer Demo
+      url: /bim-web-viewer-demo
+    - title: Novorender BIM Web Viewer (Experimental)
+      url: /novolib-bim-web-viewer
+
+- title: Announcements
+  items:
+    - title: Changelog
+      url: /overview
+    - title: Agentic APIs
+      url: /agentic-apis
+    - title: "Deprecation: Project Directory Update Webhooks"
+      url: /webhook-fanout-migration
+    # - title: New REST V2 Version
+    #   url: /new-rest-v2-version - Retired 2026-08-17, merged into /rest-api-overview. Needed for Redirect

--- a/_includes/need_help_section.md
+++ b/_includes/need_help_section.md
@@ -12,17 +12,17 @@ We’re here to support you at every step of your journey. Here’s how to get h
   <tbody>
     <tr>
       <td><strong>API & Technical Support</strong></td>
-      <td><a href="https://developers.procore.com/developer_support">apisupport@procore.com</a></td>
+      <td class="link-cell"><a href="https://developers.procore.com/developer_support">apisupport@procore.com</a></td>
       <td>Issues with APIs, authentication, Sandbox, and app types</td>
     </tr>
     <tr>
       <td><strong>Technology Partner Program</strong></td>
-      <td><a href="mailto:techpartners@procore.com">techpartners@procore.com</a></td>
+      <td class="link-cell"><a href="mailto:techpartners@procore.com">techpartners@procore.com</a></td>
       <td>Questions about agreements, vetting, or intake process</td>
     </tr>
     <tr>
       <td><strong>Marketplace QA</strong></td>
-      <td><a href="mailto:marketplaceqa@procore.com">marketplaceqa@procore.com</a></td>
+      <td class="link-cell"><a href="mailto:marketplaceqa@procore.com">marketplaceqa@procore.com</a></td>
       <td>App review status, listing changes, and validation feedback</td>
     </tr>
   </tbody>

--- a/additional_resources/faq.md
+++ b/additional_resources/faq.md
@@ -105,18 +105,6 @@ As a result, Procore does not publish a list of IP addresses for whitelisting pu
 If your internal network environment requires whitelisted IPs in order to allow access, we suggest hosting a server outside your network (e.g.
 in a network DMZ) to proxy requests from Procore into the internal network.
 
-## JSON
-
-**What is JavaScript Object Notation (JSON)?**
-
-JSON is an open-standard file format that uses human-readable text to transmit data objects consisting of attribute–value pairs and array data types. It is the data format used for Procore API requests/responses.
-
-**Is there a standard design pattern for how object attributes are ordered in Procore API JSON responses?**
-
-No. In general, an object will have an unordered set of name/value pairs.
-On the other hand, you may sometimes see ordered lists, either lexically or otherwise.
-However, this is not something you should generally expect or rely on for Procore API endpoints, new or existing.
-
 ## Testing
 
 **What is the recommended method for testing my Procore API calls?**
@@ -179,7 +167,8 @@ For additional information see [What is App Management?](https://support.procore
 
 **I'm receiving a particular error code. What does it mean?**
 
-Our [RESTful API Concepts]({{ site.url }}{{ site.baseurl }}{% link api_essentials/restful_api_concepts.md %}) guide includes a section that lists standard error codes you may encounter while working with the Procore API.
+The [Error Code Reference]({{ site.url }}{{ site.baseurl }}{% link api_essentials/error_reference.md %}) lists the status codes you may encounter, their common causes, and how to resolve each one.
+For symptom-based help, see [Troubleshooting]({{ site.url }}{{ site.baseurl }}{% link api_essentials/troubleshooting.md %}).
 If you need additional assistance with dealing with errors, please contact <apisupport@procore.com>.
 <br><br>
 

--- a/announcements/agentic_apis.md
+++ b/announcements/agentic_apis.md
@@ -92,4 +92,5 @@ Dates are directional, not committed. Subscribe through the form above to hear w
 - [API Usage Guidelines]({{ site.url }}{{ site.baseurl }}{% link platform_concepts/api_usage_guidelines.md %}) for when to use REST versus Agentic
 - [Developer Policy]({{ site.url }}{{ site.baseurl }}{% link app_marketplace/marketplace_policy.md %}) for data handling and acceptable use
 - [Announcements]({{ site.url }}{{ site.baseurl }}{% link announcements/overview.md %}) for the platform changelog
+{: .link-list}
 <br><br>

--- a/announcements/new_rest_v2_version.md
+++ b/announcements/new_rest_v2_version.md
@@ -5,6 +5,24 @@ layout: default
 section_title: Announcements
 ---
 
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=/documentation/rest-api-overview" />
+  </head>
+  <body>
+    <p>If you are not redirected, <a href="/documentation/rest-api-overview">click here</a>.</p>
+  </body>
+</html>
+
+<!-- Retired 2026-08-17. Merged into REST API Overview (/rest-api-overview) as the "REST v2" section.
+     Rationale: the content was evergreen concept material (path format, data envelope, string IDs,
+     pagination, error format) sitting in Announcements, where readers expect dated news. It also left
+     REST API Overview documenting only the v1 URL scheme, which was misleading about v2's
+     company/project-scoped paths. Trimmed on merge: the pagination detail now links to /pagination and
+     the error-format note links to /error-reference rather than restating either.
+     Original content preserved below for reference.
+
 ## What is Procore’s Rest V2 API
 
 Procore’s Rest V2 API is a new major version of Procore Rest API, introducing significant updates in the areas of consistency and performance.
@@ -72,3 +90,4 @@ GET /rest/v2.0/companies/{company_id}/items
 
 # And the associated pagination information is provided with these response headers `Per-Page`, `Total`, and `Link`.
 ```
+-->

--- a/api_essentials/app_performance_metrics.md
+++ b/api_essentials/app_performance_metrics.md
@@ -3,7 +3,7 @@ permalink: /api-activity-export
 title: API Call Activity Report
 sub_header: Generate a 30-day CSV of your app's production API calls — endpoints, status codes, and timestamps — to investigate observations, troubleshoot issues, and track usage trends.
 layout: default
-section_title: Reference
+section_title: Manage & Monitor Your App
 ---
 
 ## Overview

--- a/api_essentials/error_reference.md
+++ b/api_essentials/error_reference.md
@@ -9,7 +9,7 @@ section_title: Reference
 ## Overview
 When making calls to the Procore API, you may encounter HTTP status codes that indicate the success or failure of your request. This page provides a comprehensive reference for common error codes, their causes, and how to resolve them.
 
-For general REST API concepts, see [RESTful API Concepts]({{ site.url }}{{ site.baseurl }}{% link api_essentials/restful_api_concepts.md %}).
+This page is the single source of truth for Procore API status codes. For how requests and responses are structured, see [API Request and Response Format]({{ site.url }}{{ site.baseurl }}{% link api_essentials/restful_api_concepts.md %}).
 <br><br>
 
 ***
@@ -82,7 +82,7 @@ A `403 Forbidden` on a specific endpoint usually means the authenticated user's 
 ## See Also
 
 - [Troubleshooting]({{ site.url }}{{ site.baseurl }}{% link api_essentials/troubleshooting.md %})
-- [RESTful API Concepts]({{ site.url }}{{ site.baseurl }}{% link api_essentials/restful_api_concepts.md %})
+- [API Request and Response Format]({{ site.url }}{{ site.baseurl }}{% link api_essentials/restful_api_concepts.md %})
 - [Rate Limiting]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/rate_limiting.md %})
 - [Authentication Endpoints]({{ site.url }}{{ site.baseurl }}{% link oauth/oauth_endpoints.md %})
 - [FAQ]({{ site.url }}{{ site.baseurl }}{% link additional_resources/faq.md %})

--- a/api_essentials/integration_health.md
+++ b/api_essentials/integration_health.md
@@ -3,7 +3,7 @@ permalink: /integration-health
 title: Integration Health
 sub_header: Monitor your app's health and compliance against Procore's best practices — what each observation means, why it matters, and how to resolve unhealthy states.
 layout: default
-section_title: Reference
+section_title: Manage & Monitor Your App
 ---
 
 ## Overview

--- a/api_essentials/rate_limit_increase.md
+++ b/api_essentials/rate_limit_increase.md
@@ -1,0 +1,119 @@
+---
+permalink: /rate-limit-increase
+title: Request a Rate Limit Increase
+sub_header: What Procore reviews when you ask for a higher API rate limit, how to apply, and how to keep an increase once you have it.
+layout: default
+section_title: Manage & Monitor Your App
+
+---
+## Overview
+
+Procore's default rate limits fit most integrations. If your app has outgrown them, you can request a higher limit for that app.
+
+Increases are granted per app and are based on demonstrated production usage. The API Review Board evaluates every request against your app's actual traffic from the past 30 days.
+
+An increase raises your ceiling. It does not change the behavior that reached the old one. An app generating a high volume of `403` or other client errors is not fixed by more quota — the underlying problem goes unaddressed, and a higher ceiling lets it run further before anything surfaces. Resolve the behavior first, or an increase makes the situation worse rather than better.
+
+> **Optimize before you apply.** Requests built on an already-efficient call pattern review faster and are approved more often. See [Rate Limiting]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/rate_limiting.md %}).
+{: .callout .callout--note}
+
+***
+## Before you apply
+
+Work through the efficiency practices in [Rate Limiting]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/rate_limiting.md %}#tips-for-working-within-the-rate-limit) first — index endpoints, caching, and reduced polling.
+
+Then review both of the following, because they answer different questions:
+
+- [Integration Health]({{ site.url }}{{ site.baseurl }}{% link api_essentials/integration_health.md %}) tells you whether Procore has flagged your app against platform best practices, and what to fix.
+- [API Call Activity Report]({{ site.url }}{{ site.baseurl }}{% link api_essentials/app_performance_metrics.md %}) shows the underlying detail — which endpoints drive your volume and where your errors are concentrated.
+
+If Integration Health flags errors, especially `4xx` responses, resolve those first. They weaken the case for an increase, and they will still be there afterward.
+
+> **Failed calls consume your quota.** A `400`, `403`, or `404` counts against your limit exactly like a successful call, so reducing your error rate recovers capacity directly. See [Rate Limiting]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/rate_limiting.md %}).
+{: .callout .callout--note}
+
+***
+## Consider whether more quota is the right fix
+
+Some workloads are better served by a different approach. These are worth evaluating before you apply, and in some cases they remove the need for an increase entirely.
+
+**Confirm which limit you are actually hitting.** Procore enforces an hourly limit and a spike limit measured over a 10-second window. Only the hourly limit is requestable — the spike limit is set by Procore and adjusts alongside it. If your traffic fits within the hour but arrives in bursts, you are hitting the spike limit, and more hourly quota will not help. Pace your calls across the window instead. See [Rate Limiting]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/rate_limiting.md %}).
+
+**Combine less frequent polling with webhooks.** Apps that poll unchanged data on a short interval spend most of their quota confirming that nothing happened. Subscribe to webhooks so changes reach you as they occur, and keep polling as a reconciliation pass on a longer interval rather than as your primary change-detection mechanism. The two together cost far less quota than frequent polling alone, and you keep a safety net for any event you miss. See [How Webhooks Work]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/webhooks.md %}).
+
+**Point reporting and warehouse loads at Procore Analytics.** The REST API is transactional — it is built for reading and writing records as work happens, not for bulk extraction. If the goal is hydrating a data warehouse or a business intelligence tool, Procore Analytics is designed for that workload and does not consume your API quota.
+
+Procore Analytics is licensed at the company level. If you are building an integration for your own company, check with your Procore administrator or account team about whether it is already available to you. If you are building on behalf of a customer, raise it with that company. See <a href="https://v2.support.procore.com/process-guides/getting-started-with-analytics/" target="_blank">Getting Started with Procore Analytics</a>.
+<br><br>
+
+***
+## What we review
+
+Every signal below comes from your app's own production traffic over the past 30 days.
+
+| What we review | What we look for | Where to check |
+| --- | --- | --- |
+| Traffic consistency | Sustained production traffic that regularly approaches your current limit. | [API Call Activity Report]({{ site.url }}{{ site.baseurl }}{% link api_essentials/app_performance_metrics.md %}) |
+| Backoff behavior | Call volume that drops after a `429`. Apps that keep sending at the same or higher rate are declined. | [Integration Health]({{ site.url }}{{ site.baseurl }}{% link api_essentials/integration_health.md %}) — see the **429 Rate Limit Responses** observation |
+| Error rate | A low rate of non-`429` client errors. Frequent `400`, `403`, or `422` responses point to unresolved integration issues, and they consume quota you are asking us to expand. | [Integration Health]({{ site.url }}{{ site.baseurl }}{% link api_essentials/integration_health.md %}) |
+| Endpoint usage patterns | Volume that reflects real work being done rather than polling or per-record calls an index endpoint could batch. | [API Call Activity Report]({{ site.url }}{{ site.baseurl }}{% link api_essentials/app_performance_metrics.md %}) |
+
+<div class="details-bottom-spacing"></div>
+
+***
+## Requests we typically decline
+
+We rarely approve an increase in these cases:
+
+- **No production activity behind an ongoing request.** We size ongoing limits against real traffic, so an app with no production API calls has nothing to size against. Run the app in production first, then apply. Time-boxed work is the exception — see [Temporary increases](#temporary-increases).
+- **No backoff after a `429`.** An app that keeps sending at the same or higher rate after being throttled is declined. Add backoff logic first. See [Rate Limiting]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/rate_limiting.md %}).
+- **A high non-`429` client error rate.** Frequent `400`, `403`, or `422` responses signal unresolved integration issues, and they are already spending the quota you want more of. Resolve those before requesting more capacity.
+- **Volume driven by patterns a different approach would solve.** Polling that webhooks could replace, per-record calls that an index endpoint could batch, or bulk extraction better served by Procore Analytics. We will point you to the alternative rather than raise a limit the workload should not need.
+- **Anticipated volume with nothing live behind it.** Apply once the traffic exists rather than ahead of a projected rollout.
+
+A declined request is not final. Reapply once the underlying issue is resolved and your traffic shows it.
+<br><br>
+
+***
+## How to apply
+
+1. Confirm your app is running in production and generating consistent traffic.
+2. Review your [Integration Health]({{ site.url }}{{ site.baseurl }}{% link api_essentials/integration_health.md %}) status, then download your [API Call Activity Report]({{ site.url }}{{ site.baseurl }}{% link api_essentials/app_performance_metrics.md %}) to investigate further.
+3. Submit the <a href="https://docs.google.com/forms/d/e/1FAIpQLSenx8lYZ0poOThE6qaxUuMIGwgmFtvDgA7oOxYQa6BdS2V5hg/viewform" target="_blank">API Rate Limit Increase Request form</a>.
+
+The form explains what each field needs. Two values are worth locating before you start, because neither is in front of you when you open it:
+
+- **Developer App URL** — your request cannot be reviewed without it. Log in to the <a href="https://developers.procore.com/developers" target="_blank">Developer Portal</a>, open **My Apps**, and select your app, then copy the URL from your browser address bar.
+- **Company ID** — the Procore company submitting the request. Retrieve it from the <a href="https://developers.procore.com/reference/rest/v1/companies?version=1.0" target="_blank">List Companies</a> endpoint.
+<br><br>
+
+***
+## Temporary increases
+
+Some work needs headroom for a defined period rather than permanently — a data migration, an archival job, or a one-time backfill. Give an end date on the form rather than requesting an ongoing increase.
+
+A temporary increase is granted with an agreed revert date. On that date your app returns to its previous limit, so plan the work to finish inside the window.
+<br><br>
+
+***
+## Keeping your increase
+
+> **Inactive apps lose their increase, without advance notice.** An app that records zero production API calls for a full calendar month returns to the default limits.
+{: .callout .callout--warning}
+
+We review approved increases for continued use. Removing headroom from dormant apps keeps capacity available for integrations that are actively using it.
+
+Because there is no advance notification, treat the `X-Rate-Limit-*` response headers as the source of truth for your current limit. An app returning from a dormant period should read them before resuming heavy traffic. See [Rate Limiting]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/rate_limiting.md %}).
+
+Removal is not permanent. If your app becomes active again, apply through the same form and reference the previous increase.
+<br><br>
+
+***
+## Next steps
+- [Rate Limiting]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/rate_limiting.md %}) — headers, `429` handling, and efficiency practices.
+- [Integration Health]({{ site.url }}{{ site.baseurl }}{% link api_essentials/integration_health.md %}) — the status we review with your request.
+- [API Call Activity Report]({{ site.url }}{{ site.baseurl }}{% link api_essentials/app_performance_metrics.md %}) — the 30-day CSV that shows what drives your volume.
+<br><br>
+
+***
+{% include need_help_section.md %}

--- a/api_essentials/restful_api_concepts.md
+++ b/api_essentials/restful_api_concepts.md
@@ -1,6 +1,7 @@
 ---
 permalink: /restful-api-concepts
-title: RESTful API Concepts
+title: API Request and Response Format
+sub_header: How Procore API requests and responses are structured — transport, supported methods, JSON payloads, and user IDs.
 layout: default
 section_title: Reference
 
@@ -8,26 +9,19 @@ section_title: Reference
 
 ## Overview
 
-Representational state transfer (REST) is a common architectural style used for web development.
-Systems and sites designed using this style aim for fast performance, reliability and the ability to scale easily.
+This page covers the conventions that apply to every Procore API call regardless of which resource you are working with: how requests must be transported, which HTTP methods are supported, how request and response payloads are shaped, and how user IDs are scoped.
 
-## Resources
-
-The primary abstraction of information in a REST architecture is a resource.
-Any information that can be named can be a resource - a document or image, a service, a collection of other resources, and so on.
-Resources comprise data and functionality and are accessed using Uniform Resource Identifiers (URIs).
-Resources are acted upon by using a set of standard, well-defined operations.
-Clients and servers exchange representations of resources by using a standardized interface and protocol – typically HTTP.
+For status codes and error responses, see [Error Code Reference]({{ site.url }}{{ site.baseurl }}{% link api_essentials/error_reference.md %}).
+For versioning and URL structure, see [REST API Overview]({{ site.url }}{{ site.baseurl }}{% link getting_started/rest_api_overview.md %}).
 
 > **HTTPS protocol requirement.** Because all Procore API resources are protected by Secure Sockets Layer (SSL) encryption, any call you make to a Procore API resource must use the `HTTPS` scheme in the URL.
 > SSL establishes an encrypted link between the Procore resource server and your application.
 > This link ensures that all data passed between the resource server and your application remains private.
 {: .callout .callout--warning}
 
-## HTTP Resource Methods
+## Supported HTTP Methods
 
-Another important characteristic of REST is the use of resource methods to perform a desired operation.
-Similar to other RESTful APIs, Procore API supports the following set of standard HTTP verbs as resource methods.
+The Procore API supports the following HTTP verbs as resource methods.
 
 | HTTP Verb | CRUD    | Description                                                                                                                                                                                                             |
 | ----------| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -36,7 +30,8 @@ Similar to other RESTful APIs, Procore API supports the following set of standar
 | PATCH     | Update  | Partial update of existing resources. For example, if you wanted to change the status of an RFI, you would perform a PATCH call where you could update just the status of the RFI or change other supported parameters. |
 | DELETE    | Delete  | Delete resources. Use the DELETE call to remove an existing resource.       |
 
-To learn more about HTTP verbs as RESTful methods, see... [HTTP Methods for RESTful Services](https://www.restapitutorial.com/lessons/httpmethods.html).
+> **Procore uses PATCH, not PUT, for updates.** Updates are partial — send only the attributes you intend to change. `PUT` is not supported.
+{: .callout .callout--note}
 
 ## API Requests and Responses
 
@@ -124,42 +119,22 @@ The following example shows the response from the request shown above.
 }
 ```
 
-## HTTP Status Codes
+### Attribute Ordering
 
-Every request includes a HTTP status code with the result.
-The code indicates the success or failure of an API request.
-In general, codes in the **2xx range indicate success**, codes in the **4xx indicate an error** with the provided information, and codes in the **5xx range indicate a server-side error**.
-
-**Successful status codes (2xx)**
-
-- **200 OK** - The request was successful.
-- **201 Created** - The resource was successfully created. Confirms a success when creating a new employee, time off request, etc.
-
-**Client error status codes (4xx)**
-
-- **400 Bad Request** - The request was invalid or could not be understood by the server. Resubmitting the request will likely result in the same error.
-- **401 Unauthorized** - Your API key is missing.
-- **403 Forbidden** - The application is attempting to perform an action it does not have privileges to access. Verify your API key belongs to an enabled user with the required permissions.
-- **404 Not Found** - The resource was not found with the given identifier. Either the URL given is not a valid API, or the ID of the object specified in the request is invalid.
-- **406 Not Acceptable** - The request contains references to non-existent fields.
-- **409 Conflict** - The request attempts to create a duplicate and conflicts with the current state of the server.
-- **422 Unprocessable Entity** - The structure, syntax, etc of the API call was correct, but due to business logic the server is unable to process the request.
-- **429 Limit Exceeded** - Too many requests in a given amount of time (see [Rate Limiting]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/rate_limiting.md %})).
-
-**Server error status codes (5xx)**
-
-- **500 Internal Server Error** - The server encountered an error while processing your request and failed.
-- **502 Gateway Error** - The load balancer or web server had trouble connecting to the backend service. Please try the request again.
-- **503 Service Unavailable** - The service is temporarily unavailable. Please try the request again.
-
-You can future proof your code by using the following status code ranges:
-
-- 200–299 as success
-- 400–499 as client request errors
-- 500–599 as server errors
+Do not rely on the order of attributes in a JSON response.
+In general, an object has an unordered set of name/value pairs.
+You may sometimes see ordered lists, either lexically or otherwise, but this is not something to expect or depend on for any Procore API endpoint, new or existing.
 
 ## Globally Unique User IDs
 
 When a new user is added to Procore, the integer ID assigned to that user has global scope and is unique across all company accounts and projects.
 A user can be a member of multiple Procore company accounts by virtue of their unique email address.
 As you add that user to project-level directories within a company, the `user_id` value remains the same across those projects — it is inherited from the company-level directory.
+
+## See Also
+
+- [Error Code Reference]({{ site.url }}{{ site.baseurl }}{% link api_essentials/error_reference.md %})
+- [REST API Overview]({{ site.url }}{{ site.baseurl }}{% link getting_started/rest_api_overview.md %})
+- [Pagination]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/pagination.md %})
+- [Filtering & Sorting]({{ site.url }}{{ site.baseurl }}{% link tutorials/filtering_on_list_actions.md %})
+- [Dates, Times, and Country Codes]({{ site.url }}{{ site.baseurl }}{% link best_practices/date_time.md %})

--- a/api_essentials/tls_reqs.md
+++ b/api_essentials/tls_reqs.md
@@ -5,3 +5,13 @@ layout: default
 section_title: Reference
 redirect_to: /restful-api-concepts
 ---
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=/documentation/introduction" />
+  </head>
+  <body>
+    <p>If you are not redirected, <a href="/documentation/introduction">click here</a>.</p>
+  </body>
+</html>

--- a/api_essentials/troubleshooting.md
+++ b/api_essentials/troubleshooting.md
@@ -3,7 +3,7 @@ permalink: /troubleshooting
 title: Troubleshooting
 sub_header: Solutions for common issues developers encounter when integrating with the Procore API.
 layout: default
-section_title: Reference
+section_title: Manage & Monitor Your App
 ---
 
 ## Overview

--- a/app_marketplace/marketplace_requirements.md
+++ b/app_marketplace/marketplace_requirements.md
@@ -16,7 +16,7 @@ Before building, make sure to:
 - Review our API documentation to explore <a href="https://developers.procore.com/reference/rest/docs/rest-api-overview" target="_blank">available endpoints</a> and <a href="{{ site.url }}{{ site.baseurl }}{% link plan_your_app/building_apps_app_types.md %}">app types</a>
 - Review the [API Usage Guidelines]({{ site.url }}{{ site.baseurl }}{% link platform_concepts/api_usage_guidelines.md %}) to understand how Procore's APIs are designed to be used
 - Understand <a href="{{ site.url }}{{ site.baseurl }}{% link oauth/oauth_choose_grant_type.md %}">OAuth 2.0 authentication flows</a> (User vs. Service Account)
-- Your app **must** implement proper <a href="{{ site.url }}{{ site.baseurl }}{% link api_essentials/restful_api_concepts.md %}">error handling</a> and comply with Procore's <a href="{{ site.url }}{{ site.baseurl }}{% link plan_your_app/rate_limiting.md %}">rate limits</a>
+- Your app **must** implement proper <a href="{{ site.url }}{{ site.baseurl }}{% link api_essentials/error_reference.md %}">error handling</a> and comply with Procore's <a href="{{ site.url }}{{ site.baseurl }}{% link plan_your_app/rate_limiting.md %}">rate limits</a>
 - Use your Developer Sandbox to test <a target="_blank" href="https://support.procore.com/products/online/user-guide/company-level/admin/tutorials/install-a-custom-app">app installations</a> and simulate real-world usage
 - Invite <a href="{{ site.url }}{{ site.baseurl }}{% link building_applications/building_apps_manage_collabs.md %}">collaborators</a> to your app via the Developer Portal
 <br><br>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -8,8 +8,49 @@ body {
   }
 
   a {
-  color: #f47e42;
-  text-decoration: none;
+    color: #1D5CC9;
+    text-decoration: none;
+    font-feature-settings: 'liga' off, 'clig' off;
+  }
+
+  a:hover {
+    color: #133D86;
+  }
+
+  a:focus-visible {
+    outline: 2px solid #1D5CC9;
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+
+  /* ── Link styling & accessibility ── Docs House Standards §7 (WCAG 2.2 AA) ──
+     Rule: underline when a link sits among non-link text; the underline may be
+     dropped only where the whole block is links. Nav lives outside <main>, so
+     this selector underlines content links and leaves nav chrome bare. */
+  main a {
+    text-decoration-line: underline;
+    text-decoration-style: solid;
+    text-decoration-thickness: auto;
+    text-decoration-skip-ink: auto;   /* keep descenders legible */
+    text-underline-offset: 0.15em;
+  }
+
+  /* Link-only blocks (See also lists, link-only table cells).
+     WCAG 2.5.8 Target Size (Minimum): 24x24px. The "inline" exception covers
+     links inside a sentence — it does NOT cover a stack of bare links, which is
+     why these need an explicit target box. Underline is retained for site-wide
+     consistency (3.2.4); to render these bare, add
+     `text-decoration-line: none` to the `a` rules below. */
+  main .link-list li {
+    line-height: 26px;   /* keeps adjacent targets from overlapping */
+  }
+
+  /* Vertical padding (not display:inline-block) grows the hit area past 24px while
+     leaving the link inline, so long labels still wrap mid-link. 5px each side on a
+     ~15.5px inline box lands at 25.5px. */
+  main .link-list li > a,
+  main td.link-cell > a {
+    padding-block: 5px;
   }
 
   body {
@@ -29,6 +70,9 @@ body {
 
   article section {
     max-width: 1200px;
+    /* Center the container on the FULL page (nav space counted), clamped so it never crowds the nav */
+    margin-left: max(24px, calc(50vw - 940px));
+    margin-right: auto;
     background-color: white;
     border-radius: 4px;
     box-shadow: rgb(0 0 0 / 20%) 0px 1px 2px, rgb(0 0 0 / 10%) 0px 1px 3px;
@@ -103,10 +147,13 @@ body {
   line-height: 1.4;
 }
 
+/* Underlined via text-decoration, not border-bottom — border-bottom collides
+   with descenders and can't skip ink (Docs House Standards §7). */
 .feedback-email-link {
-  color: #f57d20;
-  text-decoration: none;
-  border-bottom: 1px solid #f57d20;
+  color: #1D5CC9;
+  text-decoration: underline;
+  text-decoration-skip-ink: auto;
+  text-underline-offset: 0.15em;
   font-weight: 500;
 }
 
@@ -371,6 +418,13 @@ body {
     padding: 5px;
     opacity: 0;
     position: absolute;
+    /* 24x24 minimum target (WCAG 2.5.8) — this anchor is not inline in a sentence */
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 24px;
+    min-height: 24px;
+    box-sizing: border-box;
   }
 
   .heading-link::before {
@@ -378,6 +432,12 @@ body {
   }
 
   .heading-link:hover {
+    opacity: 1;
+  }
+
+  /* Without this a keyboard user tabs onto an invisible link — the focus ring is
+     painted but opacity:0 hides it, failing WCAG 2.4.7 Focus Visible. */
+  .heading-link:focus-visible {
     opacity: 1;
   }
 
@@ -486,19 +546,19 @@ body {
   }
 
   .helpful-widget button:hover {
-    border-color: #f47e42;
-    color: #f47e42;
+    border-color: #1D5CC9;
+    color: #1D5CC9;
   }
 
   .helpful-widget button.selected {
-    background: #fff3e0;
-    border-color: #f47e42;
-    color: #f47e42;
+    background: #EAF2FD;
+    border-color: #1D5CC9;
+    color: #1D5CC9;
     font-weight: 600;
   }
 
   .helpful-thanks {
     font-size: 13px;
-    color: #f47e42;
+    color: #1D5CC9;
     display: none;
   }

--- a/assets/css/nav.css
+++ b/assets/css/nav.css
@@ -5,11 +5,11 @@
    ============================================================ */
 
 article {
-  padding: 48px;
+  padding: 48px 48px 48px 0; /* no left padding so the content card can center on the full page (past the nav) */
 }
 
 nav {
-  width: 300px;
+  width: 340px;
   box-sizing: border-box;
   height: 100vh;
   position: sticky;
@@ -294,6 +294,11 @@ html.nav-locked {
 
   article {
     padding: 0;
+  }
+
+  /* Mobile: cancel the desktop page-centering offset — content is full-width in the drawer layout */
+  article section {
+    margin-left: 0;
   }
 
   /* Nav becomes a left slide-in drawer */

--- a/best_practices/country_codes.md
+++ b/best_practices/country_codes.md
@@ -3,8 +3,24 @@ permalink: /country-codes
 title: Working with Country Codes
 layout: default
 section_title: Reference
-
 ---
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=/documentation/date-time" />
+  </head>
+  <body>
+    <p>If you are not redirected, <a href="/documentation/date-time">click here</a>.</p>
+  </body>
+</html>
+
+<!-- Retired 2026-08-17. Merged into Dates, Times, and Country Codes (/date-time).
+     Rationale: the page was a single concept (use ISO-3166 Alpha-2) plus an endpoint list, which the
+     Page Granularity & Content Minimalism Standard classifies as a section, not a page. It also told the
+     reader not to maintain a code table while existing largely to host one. Both halves now live under
+     "Country and State Codes" on /date-time, alongside the other value-format guidance.
+     Original content preserved below for reference.
 
 ## Overview
 
@@ -33,3 +49,4 @@ Here are the Procore API endpoints that include `country_code` and `state_code` 
 
 - [Dates, Times & Time Zones]({{ site.url }}{{ site.baseurl }}{% link best_practices/date_time.md %})
 - [Filtering & Sorting]({{ site.url }}{{ site.baseurl }}{% link tutorials/filtering_on_list_actions.md %})
+-->

--- a/best_practices/date_time.md
+++ b/best_practices/date_time.md
@@ -1,6 +1,7 @@
 ---
 permalink: /date-time
-title: Dates, Times & Time Zones
+title: Dates, Times, and Country Codes
+sub_header: Format dates, times, time zones, and ISO country and state codes correctly in Procore API requests.
 layout: default
 section_title: Reference
 
@@ -111,6 +112,26 @@ For example, if you are sending a `due_date` field value it must contain the tim
 In the example above we are sending `2018-06-26T00:00:00Z` for the `due_date` attribute value with the time component simply being `T00:00:00Z`.
 Note that if you do not send a properly formatted value the POST request will not fail, but it will be stored as a `null` value in the database.
 Here is a [downloadable JavaScript example]({{ site.baseurl }}/assets/static/datetime-post-sample-code.html) that helps illustrate how to properly include date/time data in the request body in the context of a single-page JavaScript application.
+<br><br>
+
+***
+## Country and State Codes
+
+Procore API endpoints that accept geographic location information expose `country_code` and `state_code` parameters.
+Both expect values that adhere to the Alpha-2 variant of the [ISO-3166 specification](https://www.iso.org/iso-3166-country-codes.html) — a unique, upper-case, two-character code for each country and each country subdivision.
+For example, the ISO-3166 Alpha-2 code for the United States is `US`, and the code for California is `CA`.
+
+> **Use a library, not your own lookup table.** Rather than creating and maintaining your own table of code values, leverage one of the many available ISO-3166 libraries for your language and platform. ISO owns the list and revises it — a hand-maintained copy will drift.
+{: .callout .callout--note}
+
+### Endpoints That Accept `country_code` and `state_code`
+
+- Company Users [[Create](https://developers.procore.com/reference/rest/v1/company-users#create-company-user), [Sync](https://developers.procore.com/reference/rest/v1/company-users#sync-company-users), [Update](https://developers.procore.com/reference/rest/v1/company-users#update-company-user)]
+- Company Offices [[Create](https://developers.procore.com/reference/rest/v1/company-offices#create-company-office), [Update](https://developers.procore.com/reference/rest/v1/company-offices#update-company-office)]
+- Company Vendors [[Create](https://developers.procore.com/reference/rest/v1/company-vendors#create-company-vendor), [Sync](https://developers.procore.com/reference/rest/v1/company-vendors#sync-company-vendors), [Update](https://developers.procore.com/reference/rest/v1/company-vendors#update-company-vendor)]
+- Projects [[Create](https://developers.procore.com/reference/rest/v1/projects#create-project), [Sync](https://developers.procore.com/reference/rest/v1/projects#sync-projects), [Update](https://developers.procore.com/reference/rest/v1/projects#update-project)]
+- Project Users [[Create](https://developers.procore.com/reference/rest/v1/project-users#create-project-user), [Update](https://developers.procore.com/reference/rest/v1/project-users#update-project-user)]
+- Project Vendors [[Create](https://developers.procore.com/reference/rest/v1/project-vendors#create-project-vendor), [Update](https://developers.procore.com/reference/rest/v1/project-vendors#update-project-vendor)]
 <br><br>
 
 ***
@@ -276,3 +297,12 @@ For example, using `"US Pacific Time"` will fail — use `"US/Pacific"` instead.
 | Nuku'alofa                   | Pacific           | +13:00             |
 | Samoa                        | Pacific           | +13:00             |
 | Tokelau Is.                  | Pacific           | +13:00             |
+
+<br><br>
+
+***
+## See Also
+
+- [Filtering & Sorting]({{ site.url }}{{ site.baseurl }}{% link tutorials/filtering_on_list_actions.md %})
+- [Pagination]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/pagination.md %})
+- [Error Code Reference]({{ site.url }}{{ site.baseurl }}{% link api_essentials/error_reference.md %})

--- a/building_applications/building_apps_manage_collabs.md
+++ b/building_applications/building_apps_manage_collabs.md
@@ -3,7 +3,7 @@ permalink: /building-apps-manage-collabs
 title: Managing App Collaboration
 sub_header: Learn how to manage your Procore developer app by inviting collaborators and transferring app ownership.
 layout: default
-section_title: Build Your App
+section_title: Manage & Monitor Your App
 
 ---
 

--- a/document_management_integration/document_management_api_endpoints.md
+++ b/document_management_integration/document_management_api_endpoints.md
@@ -2,9 +2,31 @@
 permalink: /document-management-api-endpoints
 title: Document Management API Endpoints
 layout: default
-section_title: Document Management Integration
-
+section_title: "Integration Guides: Document Management"
 ---
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=/documentation/document-management-technical-guide" />
+  </head>
+  <body>
+    <p>If you are not redirected, <a href="/documentation/document-management-technical-guide">click here</a>.</p>
+  </body>
+</html>
+
+<!-- Retired 2026-08-17. Killed rather than merged.
+     Rationale: the page re-hosted per-endpoint data (URIs, HTTP verbs, descriptions) that the canonical REST
+     reference already owns and that goes stale on every API version bump. Folding the table into the Technical
+     Guide was the earlier audit recommendation, but that only relocates the maintenance liability - so the
+     table was dropped entirely rather than moved.
+     Coverage check before removal: 7 of the 8 endpoints are already documented in context in the Technical
+     Guide's 8-step workflow. The eighth (List Document Uploads) is reachable from the document-uploads
+     resource page on the REST reference, which the Technical Guide links to three times - linking a resource
+     family inherently exposes all of its actions, which a hand-maintained per-action table does not.
+     Replacement: each remaining Document Management page now carries a direct link to the canonical
+     API reference in its Related Documentation block.
+     Original content preserved below for reference.
 
 This page provides a reference of all available endpoints for the Procore Document Management V2 API.
 
@@ -22,18 +44,19 @@ This page provides a reference of all available endpoints for the Procore Docume
 
 | Name | Action | Endpoint URI | Description |
 | --- | --- | --- | --- |
-| [Bulk Create Document Uploads](https://developers.procore.com/reference/rest/document-uploads?version=2.0#bulk-create-document-uploads) | POST | /rest/v2.0/companies/{company_id}/projects/{project_id}/document_management/document_uploads | Creates one or more new Document Uploads in the specified Project. |
-| [List Document Uploads](https://developers.procore.com/reference/rest/document-uploads?version=2.0#list-document-uploads-v2) | GET | /rest/v2.0/companies/{company_id}/projects/{project_id}/document_management/document_uploads | Returns a list of Document Uploads in the specified Project. |
-| [Show Document Upload](https://developers.procore.com/reference/rest/document-uploads?version=2.0#show-document-upload) | GET | /rest/v2.0/companies/{company_id}/projects/{project_id}/document_management/document_uploads/{document_upload_id} | Returns details about a Document Upload. |
-| [Bulk Update Document Uploads](https://developers.procore.com/reference/rest/document-uploads?version=2.0#bulk-update-document-uploads) | PATCH | /rest/v2.0/companies/{company_id}/projects/{project_id}/document_management/document_uploads | Updates one or more Document Uploads in the specified Project. |
-| [List Project Fields](https://developers.procore.com/reference/rest/project-fields?version=2.0#list-project-fields) | GET | /rest/v2.0/companies/{company_id}/projects/{project_id}/document_management/fields | Returns the Fields for a Project. |
-| [List Project Upload Requirements](https://developers.procore.com/reference/rest/project-upload-requirements?version=2.0#list-project-upload-requirements) | GET | /rest/v2.0/companies/{company_id}/projects/{project_id}/document_management/upload_requirements | Returns a list of Upload Requirements for the Project. |
-| [List Project Metadata Values](https://developers.procore.com/reference/rest/project-metadata-values?version=2.0#list-project-metadata-values) | GET | /rest/v2.0/companies/{company_id}/projects/{project_id}/document_management/fields/{field_id_or_name}/values | Returns a list of Metadata Values for the specified field. |
-| [Bulk Create Document Revisions](https://developers.procore.com/reference/rest/document-revisions?version=2.0#create-document-revisions-v2) | POST | /rest/v2.0/companies/{company_id}/projects/{project_id}/document_management/document_revisions | Creates one or more document revisions from document uploads. |
+| Bulk Create Document Uploads | POST | /rest/v2.0/companies/{company_id}/projects/{project_id}/document_management/document_uploads | Creates one or more new Document Uploads in the specified Project. |
+| List Document Uploads | GET | /rest/v2.0/companies/{company_id}/projects/{project_id}/document_management/document_uploads | Returns a list of Document Uploads in the specified Project. |
+| Show Document Upload | GET | /rest/v2.0/companies/{company_id}/projects/{project_id}/document_management/document_uploads/{document_upload_id} | Returns details about a Document Upload. |
+| Bulk Update Document Uploads | PATCH | /rest/v2.0/companies/{company_id}/projects/{project_id}/document_management/document_uploads | Updates one or more Document Uploads in the specified Project. |
+| List Project Fields | GET | /rest/v2.0/companies/{company_id}/projects/{project_id}/document_management/fields | Returns the Fields for a Project. |
+| List Project Upload Requirements | GET | /rest/v2.0/companies/{company_id}/projects/{project_id}/document_management/upload_requirements | Returns a list of Upload Requirements for the Project. |
+| List Project Metadata Values | GET | /rest/v2.0/companies/{company_id}/projects/{project_id}/document_management/fields/{field_id_or_name}/values | Returns a list of Metadata Values for the specified field. |
+| Bulk Create Document Revisions | POST | /rest/v2.0/companies/{company_id}/projects/{project_id}/document_management/document_revisions | Creates one or more document revisions from document uploads. |
 
 ## See Also
 
-- [Choose an Authentication Method]({{ site.url }}{{ site.baseurl }}{% link oauth/oauth_choose_grant_type.md %})
-- [Unified File Upload API]({{ site.url }}{{ site.baseurl }}{% link tutorials/tutorial_unified_uploads.md %})
-- [Rate Limiting]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/rate_limiting.md %})
-- [Procore Support: Document Management](https://v2.support.procore.com/product-manuals/document-management-project)
+- Choose an Authentication Method
+- Unified File Upload API
+- Rate Limiting
+- Procore Support: Document Management
+-->

--- a/document_management_integration/document_management_intro.md
+++ b/document_management_integration/document_management_intro.md
@@ -2,7 +2,7 @@
 permalink: /document-management-intro
 title: Document Management Integration Overview
 layout: default
-section_title: Document Management Integration
+section_title: "Integration Guides: Document Management"
 
 ---
 
@@ -15,9 +15,9 @@ Before you begin working with the various Document Management API endpoints, we 
 ## Related Documentation
 
 - **Overview** (this page)
-- [API Endpoints]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_api_endpoints.md %})
 - [Technical Guide]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_technical_guide.md %})
 - [Metadata Details]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_metadata_details.md %})
+- [API Reference: Document Management](https://developers.procore.com/reference/rest/document-uploads?version=2.0) — canonical endpoint list, maintained per API version
 
 ***
 
@@ -59,7 +59,7 @@ See [Document Management - Glossary](https://support.procore.com/products/online
 > **The steps below are a high-level workflow overview.** For detailed step-by-step implementation instructions, see [Document Management Technical Guide]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_technical_guide.md %}).
 {: .callout .callout--note}
 
-The Procore Document Management (PDM) system is a metadata-driven platform that organizes project documents based on their attributes. It provides granular permission controls and uses ML to automate metadata detection. For all available API endpoints, see [Document Management API Endpoints]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_api_endpoints.md %}).
+The Procore Document Management (PDM) system is a metadata-driven platform that organizes project documents based on their attributes. It provides granular permission controls and uses ML to automate metadata detection. For the full list of available endpoints, see the [Document Management API reference](https://developers.procore.com/reference/rest/document-uploads?version=2.0).
 
 **Step 1: Initialize Document Upload** - Create a Document Upload by providing filename and mime type. The system returns a unique upload ID.
 

--- a/document_management_integration/document_management_metadata_details.md
+++ b/document_management_integration/document_management_metadata_details.md
@@ -2,7 +2,7 @@
 permalink: /document-management-metadata-details
 title: Document Management Metadata Details
 layout: default
-section_title: Document Management Integration
+section_title: "Integration Guides: Document Management"
 
 ---
 Document metadata is the foundation of how Procore Document Management (PDM) organizes, filters, and manages documents.  
@@ -14,9 +14,9 @@ This reference describes the metadata structure returned by **Document Upload** 
 ## Related Documentation
 
 - [Overview]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_intro.md %})
-- [API Endpoints]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_api_endpoints.md %})
 - [Technical Guide]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_technical_guide.md %})
 - **Metadata Details** (this page)
+- [API Reference: Document Management](https://developers.procore.com/reference/rest/document-uploads?version=2.0) — canonical endpoint list, maintained per API version
 
 ***
 

--- a/document_management_integration/document_management_technical_guide.md
+++ b/document_management_integration/document_management_technical_guide.md
@@ -2,7 +2,7 @@
 permalink: /document-management-technical-guide
 title: Document Management Integration Technical Guide
 layout: default
-section_title: Document Management Integration
+section_title: "Integration Guides: Document Management"
 
 ---
 
@@ -12,9 +12,9 @@ This guide walks you through the complete API workflow for uploading documents, 
 ## Related Documentation
 
 - [Overview]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_intro.md %})
-- [API Endpoints]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_api_endpoints.md %})
 - **Technical Guide** (this page)
 - [Metadata Details]({{ site.url }}{{ site.baseurl }}{% link document_management_integration/document_management_metadata_details.md %})
+- [API Reference: Document Management](https://developers.procore.com/reference/rest/document-uploads?version=2.0) — canonical endpoint list, maintained per API version
 
 ***
 

--- a/erp_integration/erp_events_dictionary.md
+++ b/erp_integration/erp_events_dictionary.md
@@ -15,7 +15,7 @@ The ERP Platform is events-driven. This means that, as an integrator, you will r
 - Exporting an unsynced record (e.g. **create_commitment**)
 - Staging records from the ERP System (e.g. **sync_sub_jobs**)
 
-The event notification payload can be found [here]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/webhooks_api.md %}).
+The event notification payload is documented in [Set Up Webhooks]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/webhooks_api.md %}).
 The main property to be aware of is **resource_id**, which is the ERP Request ID. As a system integrator, you are responsible for fetching event payloads from the [ERP Requests Show](https://developers.procore.com/reference/rest/v1/erp-requests#show-erp-request) endpoint using the **resource_id** provided above.
 
 ---

--- a/example apps and sdks/procore_iframe_helper.md
+++ b/example apps and sdks/procore_iframe_helper.md
@@ -2,7 +2,7 @@
 permalink: /procore-iframe-helper
 title: Procore Iframe Helper
 layout: default
-section_title: Building Applications
+section_title: Example Apps & SDKs
 ---
 
 To aid you in developing your embedded App, we have published an open-source Javascript library to help simplify the implementation of the required authorization and authentication components of your App.

--- a/example apps and sdks/sdk.md
+++ b/example apps and sdks/sdk.md
@@ -6,7 +6,17 @@ section_title: Tools
 
 ---
 
-Software Development Kits and Sample Applications designed to get you up and running quickly with the Procore API.
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=/documentation/introduction" />
+  </head>
+  <body>
+    <p>If you are not redirected, <a href="/documentation/introduction">click here</a>.</p>
+  </body>
+</html>
+
+<!-- Software Development Kits and Sample Applications designed to get you up and running quickly with the Procore API.
 
 ## Procore JavaScript SDK
 
@@ -47,4 +57,4 @@ The application is configured to access either Procore's production environment 
 In addition, it allows you to make a test call to the [Show User Info](https://developers.procore.com/reference/me) endpoint.
 For more information, visit the link below and refer to the README page in the GitHub repository.
 
-- [Procore Python Sample App](https://github.com/procore/Procore-Sample-Python)
+- [Procore Python Sample App](https://github.com/procore/Procore-Sample-Python) -->

--- a/getting_started/rest_api_lifecycle.md
+++ b/getting_started/rest_api_lifecycle.md
@@ -3,7 +3,7 @@ permalink: /rest-api-lifecycle
 title: API Lifecycle
 sub_header: Understand the stages of Active, Deprecated, and Sunset for Procore APIs.
 layout: default
-section_title: Reference
+section_title: Platform Concepts
 ---
 
 ## API Lifecycle Phases
@@ -31,5 +31,5 @@ Please reach out to <apisupport@procore.com> if you have any questions regarding
 ## See Also
 
 - [REST API Overview]({{ site.url }}{{ site.baseurl }}{% link getting_started/rest_api_overview.md %})
-- [RESTful API Concepts]({{ site.url }}{{ site.baseurl }}{% link api_essentials/restful_api_concepts.md %})
+- [API Request and Response Format]({{ site.url }}{{ site.baseurl }}{% link api_essentials/restful_api_concepts.md %})
 - [API Usage Guidelines]({{ site.url }}{{ site.baseurl }}{% link platform_concepts/api_usage_guidelines.md %})

--- a/getting_started/rest_api_overview.md
+++ b/getting_started/rest_api_overview.md
@@ -53,6 +53,50 @@ The resource version is specified in the URL using the following format.
 
 _example_: https://api.procore.com/rest/v1.2/projects
 
+## REST v2
+
+REST v2 is a major version of the Procore REST API that introduces changes to path structure, response shape, and error formatting.
+It is not a drop-in replacement for v1 — the differences below affect how you build requests and parse responses.
+
+### Paths Are Scoped to Company and Project
+
+v2 paths begin with `/rest/v2.x/...` and most are scoped to a company and, where applicable, a project.
+
+- Company-level resources: `/rest/v2.x/companies/{company_id}/resource(s)`
+- Project-level resources: `/rest/v2.x/companies/{company_id}/projects/{project_id}/resource(s)`
+
+This differs from v1, where the company is typically supplied as the `Procore-Company-Id` header rather than in the path.
+
+### Responses Use a Data Envelope
+
+Successful (200-level) v2 responses wrap the payload in a top-level `data` key, and ID attributes are returned as **strings** rather than integers.
+
+```
+# JSON Response Example
+
+{
+  "data": {
+    "id": "160586",
+    "login": "carl.contractor@example.com",
+    "name": "Carl Contractor"
+  }
+}
+```
+
+> **Parse IDs as strings in v2.** Code that assumes integer IDs from v1 will break against v2 responses.
+{: .callout .callout--warning}
+
+### Collection Endpoints Are Paginated
+
+v2 collection endpoints — those returning an array as the main payload under `data` — are paginated, with a default page size of 10 and a maximum of 100.
+Pagination information is returned in the `Per-Page`, `Total`, and `Link` response headers.
+See [Pagination]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/pagination.md %}) for how to work with these parameters and headers.
+
+### Errors Follow a Standard Format
+
+v2 returns 400-level errors in a standardized JSON response format.
+See [Error Code Reference]({{ site.url }}{{ site.baseurl }}{% link api_essentials/error_reference.md %}) for status codes, causes, and resolutions.
+
 ## REST API Changelog
 
 The REST API includes a changelog feature.
@@ -94,3 +138,6 @@ Filters allow you to drill down on the types of changes you are most interested 
 ## Further Reading
 
 - [API Lifecycle and Deprecation]({{ site.url }}{{ site.baseurl }}{% link getting_started/rest_api_lifecycle.md %})
+- [API Request and Response Format]({{ site.url }}{{ site.baseurl }}{% link api_essentials/restful_api_concepts.md %})
+- [Pagination]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/pagination.md %})
+- [Error Code Reference]({{ site.url }}{{ site.baseurl }}{% link api_essentials/error_reference.md %})

--- a/oauth/oauth_keys.md
+++ b/oauth/oauth_keys.md
@@ -2,7 +2,7 @@
 permalink: /oauth-keys
 title: OAuth Credentials Management
 layout: default
-section_title: Reference
+section_title: Manage & Monitor Your App
 ---
 
 ## Overview

--- a/overview/verification_and_production_access.md
+++ b/overview/verification_and_production_access.md
@@ -135,6 +135,7 @@ This step happens for every app you want to promote to production. If you build 
 - [Partner & Marketplace Overview]({{ site.url }}{{ site.baseurl }}{% link app_marketplace/procore_partner_overview.md %})
 - [Create an App]({{ site.url }}{{ site.baseurl }}{% link building_applications/building_apps_create_new.md %})
 - [Procore Environments]({{ site.url }}{{ site.baseurl }}{% link platform_concepts/development_environments.md %})
+{: .link-list}
 <br><br>
 
 ***

--- a/plan_your_app/rate_limiting.md
+++ b/plan_your_app/rate_limiting.md
@@ -14,6 +14,16 @@ The headers returned may reflect either the spike limit or the hourly limit. The
 <br><br>
 
 ***
+## What counts against your limit
+
+Every request your app sends counts against your rate limit, including requests that fail. A `400`, `403`, or `404` response consumes quota exactly like a successful call.
+
+This matters more than it first appears. An app with a high client-error rate can spend a substantial share of its hourly allocation on calls that return nothing useful — malformed requests, calls to resources the app lacks permission for, or requests to routes that do not exist. Fixing those errors can recover meaningful capacity without any change to your limit.
+
+Use the <a href="{{ site.url }}{{ site.baseurl }}{% link api_essentials/app_performance_metrics.md %}" target="_blank">API Call Activity Report</a> to see your error distribution by status code and endpoint.
+<br><br>
+
+***
 ## Interpret Rate Limit Headers
 
 There are three important rate limit headers returned when making a request to the Procore API. These values reflect your current limits. They can change at any time, so your application should always read and adapt to them.
@@ -91,5 +101,12 @@ Follow these practices to reduce the chance of hitting rate limits and to build 
 - If your app makes concurrent requests (for example, multi-threaded or trigger-based), enqueue work and control throughput by tuning concurrency (such as adjusting thread pool size).
 - Use index actions to fetch collections in one request instead of requesting individual objects.
 - Cache results whenever possible, especially for public or repeated data.
+- Subscribe to <a href="{{ site.url }}{{ site.baseurl }}{% link plan_your_app/webhooks.md %}" target="_blank">webhooks</a> for change detection and reduce how often you poll. Polling on a short interval spends most of your quota confirming that nothing changed. Keep polling as a lower-frequency reconciliation pass rather than your primary way of detecting updates.
 - Review your app’s <a href="{{ site.url }}{{ site.baseurl }}{% link api_essentials/app_performance_metrics.md %}" target="_blank">API Call Activity Report</a> to understand and optimize request patterns.
+<br><br>
+
+***
+## Request a higher limit
+
+If your app consistently approaches its limit after you have applied these practices, you can request an increase. Approval depends on your production traffic, your backoff behavior, and your error rate. See [Request a Rate Limit Increase]({{ site.url }}{{ site.baseurl }}{% link api_essentials/rate_limit_increase.md %}).
 <br><br>

--- a/platform_concepts/api_usage_guidelines.md
+++ b/platform_concepts/api_usage_guidelines.md
@@ -56,6 +56,7 @@ To maintain platform performance and stay in compliance:
 - [Agentic APIs]({{ site.url }}{{ site.baseurl }}{% link announcements/agentic_apis.md %}) — for AI agents, semantic retrieval, and advanced analytics use cases
 - [Developer Policy]({{ site.url }}{{ site.baseurl }}{% link app_marketplace/marketplace_policy.md %})
 - <a href="https://procore.pactsafe.io/legal.html#contract-hymckkfc9" target="_blank">API Terms of Use</a>
+{: .link-list}
 <br><br>
 
 ***

--- a/platform_concepts/development_environments.md
+++ b/platform_concepts/development_environments.md
@@ -133,10 +133,6 @@ Projected dates are provided for planning. Exact timing can vary based on mainte
 
 | Month | Date | Day |
 | --- | --- | --- |
-| May 2026 | 05/05/2026 | Tuesday |
-| June 2026 | 06/02/2026 | Tuesday |
-| July 2026 | 07/01/2026 | Wednesday |
-| August 2026 | 08/04/2026 | Tuesday |
 | September 2026 | 09/01/2026 | Tuesday |
 | October 2026 | 10/01/2026 | Thursday |
 | November 2026 | 11/03/2026 | Tuesday |

--- a/tutorials/tutorial_financial_tools.md
+++ b/tutorials/tutorial_financial_tools.md
@@ -204,7 +204,7 @@ This applies to "Payments Issued" on a commitment and "Payments Received" on a p
 ### Workflow
 
 Procore’s workflow tool provides control of the status field on certain objects in Procore.
-See the [Workflow API]({{ site.url }}{{ site.baseurl }}{% link tutorials/tutorial_workflows.md %}) guide for additional information.
+See the [legacy Workflows API]({{ site.url }}{{ site.baseurl }}{% link tutorials/tutorial_workflows.md %}) guide, or [Interacting with Workflows]({{ site.url }}{{ site.baseurl }}{% link tutorials/tutorial_workflows_v2.md %}) for the company-level Self-Serve Workflows tool.
 
 ### Webhooks
 

--- a/tutorials/tutorial_wbs.md
+++ b/tutorials/tutorial_wbs.md
@@ -520,7 +520,7 @@ We will provide the ability to create and edit the Company and Project patterns 
 
 ## WBS and Origin IDs
 
-- Many custom integrations use the `origin_id` field in Procore to store an external unique identifier for Cost Codes, Cost Types, and Sub Jobs. Learn more about External IDs and Data [here](https://developers.procore.com/documentation/tutorial-financial-tools).
+- Many custom integrations use the `origin_id` field in Procore to store an external unique identifier for Cost Codes, Cost Types, and Sub Jobs. See [Financial Tools](https://developers.procore.com/documentation/tutorial-financial-tools) for more on External IDs and data.
 - Cost Codes, Cost Types, and Sub Jobs endpoints will continue to support the `origin_id` attribute and the functionality will not change, through Q1 2023.
 The `origin_id` is not currently available on Custom Segments or WBS Codes. This functionality may be added to some portions of WBS in the future.
 

--- a/tutorials/tutorial_workflows.md
+++ b/tutorials/tutorial_workflows.md
@@ -7,7 +7,11 @@ section_title: "Product Guides: Project Management"
 
 ## Overview
 
-Procore’s Workflows tool provides control of the status field on certain objects in Procore.
+> **Which Workflows page do I need?** This page covers the **legacy Workflows tool** and its REST v1.0 API — the `workflow_instances` and `workflow_activity_histories` endpoints. It is still supported.
+> If you are building against the **company-level Self-Serve Workflows tool** — templates, presets, and instances, with their own separate endpoints — see [Interacting with Workflows]({{ site.url }}{{ site.baseurl }}{% link tutorials/tutorial_workflows_v2.md %}) instead. The two tools have different APIs, not different versions of one API.
+{: .callout .callout--note}
+
+Procore’s legacy Workflows tool provides control of the status field on certain objects in Procore.
 Once the Workflows tool has been enabled and configured for your account, you are able to interact with the workflow on objects to perform workflow activities via the Procore API.
 
 A workflow is a Business Process Automation (BPA) solution that provides a company the ability to create customized approval processes that work with different Procore project tools.

--- a/tutorials/tutorial_workflows_v2.md
+++ b/tutorials/tutorial_workflows_v2.md
@@ -7,6 +7,10 @@ section_title: "Product Guides: Project Management"
 
 ## Overview
 
+> **Which Workflows page do I need?** This page covers the **company-level Self-Serve Workflows tool** — templates, presets, and instances, and the workflow template, preset, instance, and response endpoints.
+> If you are working with the **legacy Workflows tool** — the `workflow_instances` and `workflow_activity_histories` endpoints, still supported — see [Interacting with Workflows (Legacy)]({{ site.url }}{{ site.baseurl }}{% link tutorials/tutorial_workflows.md %}) instead. The two tools have different APIs, not different versions of one API.
+{: .callout .callout--note}
+
 The company-level Workflows tool was designed to streamline the user experience and to replace time-consuming and manual approval processes.
 Custom workflows can be created that define the responsible roles, groups, and conditions for routing an item through that approval process—and that process is tailored to suit the unique needs and specific requirements of a company's business environment.
 See [Self-Serve Workflows User Guide](https://support.procore.com/products/online/user-guide/company-level/workflows/tutorials/user-guide) for additional information on using the Workflows tool in Procore.


### PR DESCRIPTION
## Scope note

This branch is named for AGX-7149 (link accessibility), but it accumulated three further workstreams. It is split into four commits so each can be reviewed on its own — only `e279a50` is AGX-7149 proper.

| Commit | What |
|---|---|
| `e279a50` | AGX-7149: accessible link text and link styling |
| `9f253c8` | Add Request a Rate Limit Increase page; retire TLS and SDK pages |
| `72a85db` | Merge and retire redundant pages per the page-existence audit |
| `cd63e1a` | Restructure navigation around journey and library axes |

## What changed

**Link accessibility** — replaced non-descriptive "here" link text with destination names, added `.link-list` / `.link-cell` styling hooks, widened the sidebar to 340px and fixed the desktop page-centring offset with a mobile override.

**New page** — *Request a Rate Limit Increase*: what Procore reviews, what typically gets declined, how to keep an increase. Rate Limiting gains a "What counts against your limit" section making clear that 4xx responses consume quota, so fixing client errors recovers capacity without a limit change.

**Page merges and retirements** (all with redirect stubs, original bodies preserved in comments):
- Country Codes → `/date-time`, retitled *Dates, Times, and Country Codes*
- New REST V2 Version → `/rest-api-overview` as a "REST v2" section
- Document Management API Endpoints → **killed, not merged**
- RESTful API Concepts → trimmed and retitled *API Request and Response Format*
- TLS Requirements and SDKs → retired to `/introduction`

**Navigation restructure** — the nav was running on two axes while documenting one, which is why placement kept getting argued. Journey sections (Plan / Build / Manage & Monitor) hold tasks the reader performs; library sections hold knowledge they consult. *Operate Your App* → **Manage & Monitor Your App**, gaining Troubleshooting and OAuth Credentials Management from Reference and Manage App Collaborators from Build. API Lifecycle moves to Platform Concepts. Document Management takes an `Integration Guides:` prefix and moves up beside the Product Guides. Announcements moves last.

## Please look at these specifically

**API Lifecycle placement.** This moves `rest_api_lifecycle.md` to Platform Concepts. There was an uncommitted local change moving it to Operate Your App instead; this supersedes it. If that was a deliberate call by someone else, flag it.

**Workflows are two different APIs, not two versions.** An earlier audit recommended folding the legacy Workflows page into v2. That was wrong — legacy documents the BPA Workflows tool (`workflow_instances`, `workflow_activity_histories`) and v2 documents the company-level Self-Serve Workflows tool with entirely separate endpoints. Both pages are kept, each with an applicability callout. Confirmed legacy is still supported with no sunset date.

**Killing the Document Management endpoint table.** Folding it into the Technical Guide would only relocate the maintenance liability — it re-hosted URIs and descriptions that go stale on every version bump. Seven of its eight endpoints are already documented in context in the Technical Guide; the eighth is reachable from the `document-uploads` resource page the guide already links to. Each remaining page now links to the canonical API reference instead.

## User-visible impact

Two nav sections renamed, four pages relocated, five pages retired. **No live URL breaks** — every retirement has a redirect stub. Worth a heads-up to anyone linking into the docs from support or marketing.

## Verification

Checked against the committed tree (`git ls-tree HEAD`), not the working tree:
- 0 broken `{% link %}` targets repo-wide
- All 80 live nav entries resolve to a committed page
- All live pages return 200 against a local Jekyll server; retired stubs also return 200 and redirect correctly
- 0 `section_title` drift — the sidebar highlights the active group by exact string match, so every moved page had its frontmatter synced
- Secret scan over the full diff: clean

## Notes

- `Gemfile.lock` is deliberately **not** included. `Gemfile` is untouched, so the drift is a local `bundle install` resolving differently.
- Reference now sits at 12 items, past the ~7 threshold. The nav template is strictly two-level, so it cannot be nested without a front-end change — recorded as a known exception rather than a silent variance.
- **Deferred:** `/webhook-fanout-migration` is written in future tense against a June 30 2026 cutoff that has passed. Not introduced by this branch and not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)