### PR TITLE
Agx 7204 on this page nav

### DIFF
--- a/_includes/url_parameter_interpolation.md
+++ b/_includes/url_parameter_interpolation.md
@@ -43,7 +43,7 @@ Custom parameters are values the installing admin enters during setup. You defin
 
 ***
 
-## Examples
+## Interpolation Examples
 
 **Subdomain** — pass a value into the subdomain dynamically.
 ```{% raw %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,6 +8,7 @@
     <base target="_parent">
     <link rel="stylesheet" href="{{ 'assets/css/main.css' | relative_url }}">
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/nav.css"/>
+    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/toc.css"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
   </head>
@@ -60,9 +61,12 @@
           </div>
         </main>
       </section>
+      <!-- Populated by assets/js/toc.js; stays hidden on pages with too few H2s. -->
+      <nav class="toc" id="toc" hidden></nav>
     </article>
     <script src="https://unpkg.com/simple-jekyll-search@latest/dest/simple-jekyll-search.min.js"></script>
     <script src="{{ 'assets/js/nav.js' | relative_url }}"></script>
+    <script src="{{ 'assets/js/toc.js' | relative_url }}"></script>
     <script>
       function submitFeedback(value, btn) {
         var widget = document.getElementById('helpful-widget');

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,7 @@
     <nav>
     <button type="button" class="nav-close" id="nav-close" aria-label="Close menu">&times;</button>
     <div class="search-wrap">
-      <input type="text" id="search-input" placeholder="Search Articles...">
+      <input type="text" id="search-input" placeholder="Search articles">
       <button type="button" id="search-clear" class="search-clear" aria-label="Clear search">&times;</button>
       <ul id="results-container"></ul>
     </div>

--- a/additional_resources/faq.md
+++ b/additional_resources/faq.md
@@ -33,14 +33,14 @@ We also recommend visiting [learn.procore.com](https://learn.procore.com/) to ac
 
 The [Procore Support Site](https://support.procore.com/) includes a reference page with a comprehensive breakdown of all user actions and the specific user permission(s) (Read-only, Standard, and/or Admin) that are required to perform a given action.
 
-## Development environments
+## Development Environments
 
 **What time does the monthly sandbox restore?**
 
 The monthly sandbox is refreshed on the first working day of each month (morning to mid‑afternoon ET).
 To ensure that changes you make in your production environment are available in the next monthly refresh, we recommend including those changes by the end of the last working day of the current month.
 
-## OAuth 2.0 authentication
+## OAuth 2.0 Authentication
 
 **How long does my access token last?**
 
@@ -95,7 +95,7 @@ If this occurs, the following workaround will resolve the issue.
 
 - Users should explicitly navigate to “https://login.procore.com” anytime they want to access the Procore web application while simultaneously working with an integrated web application.
 
-## IP whitelisting
+## IP Whitelisting
 
 **Does Procore publish a list of IP addresses for whitelisting purposes?**
 
@@ -105,20 +105,18 @@ As a result, Procore does not publish a list of IP addresses for whitelisting pu
 If your internal network environment requires whitelisted IPs in order to allow access, we suggest hosting a server outside your network (e.g.
 in a network DMZ) to proxy requests from Procore into the internal network.
 
-## Testing
-
+## API Testing
 **What is the recommended method for testing my Procore API calls?**
 
 We recommend using <a href="https://www.postman.com/" target="_blank">Postman</a> to test Procore API endpoints. You can download the OpenAPI (OAS) spec from the <a href="https://developers.procore.com/reference/rest/docs/rest-api-overview" target="_blank">Developer Portal API Reference</a> and import it directly into Postman to get pre-configured endpoints. <a href="https://curl.se/" target="_blank">cURL</a> is also a great option for quick command-line testing.
 
-## Deprecation
-
+## Deprecation Policy
 **How is deprecation handled for Procore API endpoints, and what is the policy?**
 
 As you browse through our Procore API documentation you may see deprecation warning banners on some of our endpoint reference pages.
 Please see our [API Lifecycle guide]({{ site.url }}{{ site.baseurl }}{% link getting_started/rest_api_lifecycle.md %}) for information on our API deprecation policy.
 
-## Cross-origin resource sharing (CORS)
+## Cross-Origin Resource Sharing (CORS)
 
 **Does the Procore API support Cross-Origin Resource Sharing (CORS)?**
 
@@ -141,7 +139,7 @@ While it is certainly possible have more than one domain whitelisted for CORS, p
 Our Webhooks feature allows you to establish a system through which you can receive notifications for changes that occur to specific resources.
 Please visit our [Introduction to Webhooks]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/webhooks.md %}) and [Using the Webhooks API]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/webhooks_api.md %}) guides on the Developer Portal for additional information.
 
-## Procore API rate limit
+## Rate Limiting
 
 **I am receiving a 429 status code error when making a call to the Procore API, what causes this?**
 
@@ -154,7 +152,7 @@ See our [Rate Limiting]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/ra
 
 Yes. If the endpoint you are working with normally requires a `company_id` as either a path or query parameter, you still need to include it in your call, regardless of MPR header requirements.
 
-## App management
+## App Management
 
 **I’ve suddenly started getting a 403 forbidden error with the message "App is not connected to this company". Why is this?**
 
@@ -163,7 +161,7 @@ As a result, your application is no longer able to access data in that company.
 To resolve this issue, use the App Management page in Procore Web to reconnect your application to that company.
 For additional information see [What is App Management?](https://support.procore.com/faq/what-is-app-management).
 
-## Error codes
+## Error Codes
 
 **I'm receiving a particular error code. What does it mean?**
 

--- a/announcements/agentic_apis.md
+++ b/announcements/agentic_apis.md
@@ -25,8 +25,7 @@ If your app currently uses REST APIs for AI-powered features or large-scale data
 
 ***
 
-## Using the Converse API
-
+## Use the Converse API
 The Converse API takes a natural-language prompt and returns an agent's response, with optional citations to source records and a conversation ID for multi-turn follow-ups. Call-level options include streaming, structured output, and citation generation. Agent-level behavior — knowledge sources, tools, and Model Context Protocol (MCP) server connections — is configured on the agent itself and can be overridden per call.
 
 Most use cases — agents, RAG, semantic search — are built by configuring different agents and calling Converse, rather than against many purpose-built endpoints.
@@ -52,7 +51,7 @@ Most use cases — agents, RAG, semantic search — are built by configuring dif
 
 ***
 
-## Get early access
+## Get Early Access
 
 The Ecosystem team reviews Design Partner pilot submissions on a rolling basis. We select partners based on whether the use case fits the API's capabilities and whether customers are asking for it. Pilot use cases are reviewed through the same partnership review process as other Marketplace integrations.
 
@@ -74,8 +73,7 @@ Here's what happens after you submit:
 
 ***
 
-## Roadmap
-
+## Planned Capabilities
 In development:
 
 - Declaring agentic components (MCP servers and agents) in your app manifest through the Developer Portal, so Marketplace customers can install your agent without a separate Datagrid relationship
@@ -86,7 +84,7 @@ Dates are directional, not committed. Subscribe through the form above to hear w
 
 ***
 
-## See also
+## See Also
 
 - <a href="https://developers.datagrid.com/api-reference/converse/converse" target="_blank">Converse API reference</a>
 - [API Usage Guidelines]({{ site.url }}{{ site.baseurl }}{% link platform_concepts/api_usage_guidelines.md %}) for when to use REST versus Agentic

--- a/announcements/overview.md
+++ b/announcements/overview.md
@@ -11,7 +11,7 @@ This page tracks significant changes to the Procore Developer Platform, includin
 <br><br>
 
 ***
-## April 2026 — Project Directory Webhook Update Triggers Deprecated
+## April 2026 — Directory Update Triggers Deprecated
 **Category:** Deprecation
 
 We are deprecating the `update` event type on the **Project Users** and **Project Vendors** webhook triggers. These triggers cause a fanout issue — a single contact edit in the Directory tool can generate hundreds or thousands of duplicate webhook events across projects.

--- a/announcements/webhook_fanout_migration.md
+++ b/announcements/webhook_fanout_migration.md
@@ -6,7 +6,15 @@ layout: default
 section_title: Announcements
 ---
 
-## What is changing
+## Overview
+
+The `update` event type on the **Project Users** and **Project Vendors** webhook triggers is being deprecated, with a hard cutoff of **June 30, 2026**.
+These triggers cause a fanout problem — a single contact edit in the Directory tool can generate thousands of duplicate events across projects.
+
+This page covers what is changing, how to tell whether your app is affected, and the steps to migrate before the cutoff.
+Only the `update` event type on those two triggers is affected; `create` and `delete` continue to work, as do all Company Directory triggers.
+
+## What Is Changing
 
 Procore is deprecating the `update` event type on two webhook triggers: **Project Users** and **Project Vendors**. After **June 30, 2026**, these triggers stop delivering `update` events. Your app will no longer receive them.
 
@@ -24,7 +32,7 @@ The `create` and `delete` event types on these same triggers are **not affected*
 <br><br>
 
 ***
-## Why this is happening
+## Why We’re Deprecating These Triggers
 
 Procore's Directory tool exists at two levels: Company and Project. When a contact record is updated in a Project Directory, here is what happens:
 
@@ -44,8 +52,7 @@ One edit to one contact produces one webhook event per project that contact is a
 <br><br>
 
 ***
-## Timeline
-
+## Migration Timeline
 | Date | What happens |
 | --- | --- |
 | April 2026 | Deprecation announced. Migration window begins. |
@@ -55,7 +62,7 @@ One edit to one contact produces one webhook event per project that contact is a
 <br><br>
 
 ***
-## How to tell if your app is affected
+## How to Tell If Your App Is Affected
 
 Check whether your app subscribes to either of these trigger and event type combinations:
 
@@ -68,7 +75,7 @@ If your app only uses `create` or `delete` event types on these triggers, no mig
 <br><br>
 
 ***
-## Migration steps
+## Migration Steps
 
 ### Step 1: Subscribe to Company Directory webhooks
 
@@ -106,7 +113,7 @@ Once you have validated the new subscriptions:
 <br><br>
 
 ***
-## Quick reference
+## Quick Reference
 
 | Trigger level | Fanout risk | Recommendation |
 | --- | --- | --- |
@@ -117,7 +124,7 @@ Once you have validated the new subscriptions:
 <br><br>
 
 ***
-## Frequently asked questions
+## Frequently Asked Questions
 
 **Will my existing subscriptions break immediately?**
 No. The deprecated triggers continue to deliver events until June 30, 2026. You have a migration window to transition.

--- a/api_essentials/api_security_overview.md
+++ b/api_essentials/api_security_overview.md
@@ -11,7 +11,12 @@ Procore customers often ask how Procore secures the apps and integrations that t
 
 ***
 
-## How Procore authenticates API access
+## Overview
+
+Procore's API security model rests on OAuth 2.0: every request is authorised, every app is installed deliberately by a customer, and access can be revoked at any time.
+This page explains how authentication works, how tokens behave, how customers control what an app can reach, and where your responsibilities sit alongside Procore's.
+
+## OAuth 2.0 Authentication
 
 Procore uses <a href="https://tools.ietf.org/html/rfc6749" target="_blank">OAuth 2.0</a>, a widely adopted standard for authorizing and authenticating third-party access to user data. OAuth 2.0 lets an app act on a user's behalf without ever handling that user's Procore password or other sign-in credentials.
 
@@ -22,7 +27,7 @@ Developers choose one of several [OAuth 2.0 authorization grant types]({{ site.u
 
 ***
 
-## How access tokens behave
+## Access and Refresh Tokens
 
 OAuth 2.0 uses two kinds of tokens: _access tokens_ and _refresh tokens_.
 
@@ -35,7 +40,7 @@ In the authorization code grant, an app generates its first access token by comb
 
 ***
 
-## How apps access your data
+## App Data Access
 
 An app reaches a company's Procore data through OAuth 2.0 in one of two ways, depending on the grant type it uses. The two models differ in whose permissions the app inherits.
 
@@ -54,7 +59,7 @@ For more on the modern model, see <a href="https://v2.support.procore.com/faq-wh
 
 ***
 
-## How customers control app access
+## Customer Access Controls
 
 Every app must be installed in a company's Procore account before it can access any data there. An app that is not installed cannot function and has no access to that company's data — installation is the gate that grants an app entry to a company. For how installation works, see [How to Install & Set Up Apps]({{ site.url }}{{ site.baseurl }}{% link platform_concepts/building_apps_install_arch.md %}).
 
@@ -67,14 +72,14 @@ For a customer-facing explanation of this model, see <a href="https://v2.support
 
 ***
 
-## Rate limits
+## Rate Limits
 
 Procore enforces rate limits on API requests. Beyond keeping the platform stable, rate limits guard customers and Procore against abuse and runaway or excessive request volume from an integration. An app that exceeds the hourly limit or the short-term spike limit receives an `HTTP 429 Too Many Requests` response and should back off and retry rather than keep calling. For how the hourly and spike limits work, the rate limit headers Procore returns so your app can pace itself, and how to handle a `429`, see [Rate Limiting]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/rate_limiting.md %}) and the [API Usage Guidelines]({{ site.url }}{{ site.baseurl }}{% link platform_concepts/api_usage_guidelines.md %}).
 <br><br>
 
 ***
 
-## Shared responsibility for security
+## Shared Responsibility for Security
 
 Securing an integration is a shared responsibility across Procore, the developers who build integrations, and the customers who install them.
 
@@ -87,7 +92,7 @@ Some Marketplace listings display a **Security & Trust — Partner Self-Certifie
 
 ***
 
-## Further reading
+## See Also
 
 - [Introduction to OAuth 2.0]({{ site.url }}{{ site.baseurl }}{% link oauth/oauth_introduction.md %})
 - [Choose an Authentication Method]({{ site.url }}{{ site.baseurl }}{% link oauth/oauth_choose_grant_type.md %})

--- a/api_essentials/app_performance_metrics.md
+++ b/api_essentials/app_performance_metrics.md
@@ -14,7 +14,7 @@ The report is available for **all apps** in the Procore Developer Portal, includ
 <br><br>
 
 ***
-## Why this matters
+## Why the Report Matters
 
 Use the API Call Activity Report to:
 
@@ -26,7 +26,7 @@ Use the API Call Activity Report to:
 <br><br>
 
 ***
-## How to generate the report
+## How to Generate the Report
 
 1. Log in to the [Procore Developer Portal](https://developers.procore.com/developers).
 2. Open **My Apps** and select the app you want to inspect.
@@ -51,7 +51,7 @@ The CSV covers the last 30 days of your app's **production** API calls.
 <div class="details-bottom-spacing"></div>
 
 ***
-## Tips for using this data
+## Tips for Using This Data
 
 - **Investigating a Needs Attention observation?** Filter by the relevant Response Code (401/403/404/429) and sort by Count descending — the top rows are usually the offenders.
 - **Spot errors quickly** — filter by failed calls to identify problem endpoints.
@@ -63,7 +63,7 @@ By regularly reviewing your app's API activity, you can maintain reliability, im
 <br><br>
 
 ***
-## Related documentation
+## See Also
 
 - [Integration Health]({{ site.url }}{{ site.baseurl }}{% link api_essentials/integration_health.md %})
 - [Error Code Reference]({{ site.url }}{{ site.baseurl }}{% link api_essentials/error_reference.md %})

--- a/api_essentials/error_reference.md
+++ b/api_essentials/error_reference.md
@@ -13,7 +13,7 @@ This page is the single source of truth for Procore API status codes. For how re
 <br><br>
 
 ***
-## Successful responses (2xx)
+## Successful Responses (2xx)
 
 | Code | Status | Description |
 |------|--------|-------------|
@@ -24,7 +24,7 @@ This page is the single source of truth for Procore API status codes. For how re
 <br><br>
 
 ***
-## Client errors (4xx)
+## Client Errors (4xx)
 
 | Code | Status | Common Cause | How to Fix |
 |------|--------|-------------|------------|
@@ -41,7 +41,7 @@ This page is the single source of truth for Procore API status codes. For how re
 <br><br>
 
 ***
-## Server errors (5xx)
+## Server Errors (5xx)
 
 | Code | Status | Common Cause | How to Fix |
 |------|--------|-------------|------------|
@@ -52,7 +52,7 @@ This page is the single source of truth for Procore API status codes. For how re
 <br><br>
 
 ***
-## Common error patterns
+## Common Error Patterns
 
 ### "App is not connected to this company"
 **HTTP 403** — Your app has been disconnected from the company via App Management in Procore. The company admin needs to reconnect your app. See [What is App Management?](https://support.procore.com/faq/what-is-app-management)
@@ -69,7 +69,7 @@ A `403 Forbidden` on a specific endpoint usually means the authenticated user's 
 <br><br>
 
 ***
-## Best practices for error handling
+## Best Practices for Error Handling
 
 1. **Always check status codes** — Don't assume success. Check the response status code before processing the response body.
 2. **Parse error messages** — The response body for 4xx errors often contains a `message` or `errors` field with specific details.

--- a/api_essentials/integration_health.md
+++ b/api_essentials/integration_health.md
@@ -16,7 +16,7 @@ For a complete reference of HTTP status codes, see the [Error Code Reference]({{
 <br><br>
 
 ***
-## Where to find this in the Developer Portal
+## Open the Integration Health Tab
 
 1. Log in to the <a href="https://developers.procore.com/developers" target="_blank">Procore Developer Portal</a>.
 2. Open **My Apps** and select the app you want to inspect.
@@ -30,7 +30,7 @@ The page is organized into three areas:
 <br><br>
 
 ***
-## Status states
+## What Each Status Means
 
 > **Start every investigation with the API Call Activity Report.** When an observation is flagged, it is your fastest path to the root cause, and every remediation step below begins here.
 {: .callout .callout--note}
@@ -49,7 +49,7 @@ Expand any observation row to see its **Daily status** — the raw severity (`Cr
 <br><br>
 
 ***
-## How your status improves
+## How Your Status Improves
 
 Because Integration Health is a rolling 14-day view, your status recovers on its own once you fix the underlying issue — there's nothing to manually clear or dismiss.
 
@@ -61,7 +61,7 @@ Use the **API Call Activity Report** after each release to confirm the offending
 <br><br>
 
 ***
-## Recommended monitoring cadence
+## Recommended Monitoring Cadence
 
 Treat Integration Health as part of your operational rhythm rather than something you check only when alerted:
 
@@ -74,8 +74,7 @@ Treat Integration Health as part of your operational rhythm rather than somethin
 <br><br>
 
 ***
-## Observations
-
+## The Seven Observations
 This section covers each of the seven observations shown on the Integration Health tab. Expand the observation that matches your status pill to see what it means and how to resolve it. **Every resolution path starts with the API Call Activity Report** — download it to see the exact endpoints, status codes, and daily counts behind each flagged observation.
 <br><br>
 
@@ -212,7 +211,7 @@ This section covers each of the seven observations shown on the Integration Heal
 <div class="details-bottom-spacing"></div>
 <div class="details-bottom-spacing"></div>
 
-## Frequently asked questions
+## Frequently Asked Questions
 
 ### Where do I find the API Call Activity Report?
 
@@ -245,7 +244,7 @@ Each status reflects the mix of critical and warning days across the rolling 14-
 <br><br>
 
 ***
-## Related documentation
+## See Also
 
 - [Troubleshooting]({{ site.url }}{{ site.baseurl }}{% link api_essentials/troubleshooting.md %})
 - [Error Code Reference]({{ site.url }}{{ site.baseurl }}{% link api_essentials/error_reference.md %})

--- a/api_essentials/rate_limit_increase.md
+++ b/api_essentials/rate_limit_increase.md
@@ -18,7 +18,7 @@ An increase raises your ceiling. It does not change the behavior that reached th
 {: .callout .callout--note}
 
 ***
-## Before you apply
+## Before You Apply
 
 Work through the efficiency practices in [Rate Limiting]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/rate_limiting.md %}#tips-for-working-within-the-rate-limit) first — index endpoints, caching, and reduced polling.
 
@@ -33,7 +33,7 @@ If Integration Health flags errors, especially `4xx` responses, resolve those fi
 {: .callout .callout--note}
 
 ***
-## Consider whether more quota is the right fix
+## Consider Whether More Quota Is the Right Fix
 
 Some workloads are better served by a different approach. These are worth evaluating before you apply, and in some cases they remove the need for an increase entirely.
 
@@ -47,7 +47,7 @@ Procore Analytics is licensed at the company level. If you are building an integ
 <br><br>
 
 ***
-## What we review
+## What We Review
 
 Every signal below comes from your app's own production traffic over the past 30 days.
 
@@ -61,7 +61,7 @@ Every signal below comes from your app's own production traffic over the past 30
 <div class="details-bottom-spacing"></div>
 
 ***
-## Requests we typically decline
+## Requests We Typically Decline
 
 We rarely approve an increase in these cases:
 
@@ -75,7 +75,7 @@ A declined request is not final. Reapply once the underlying issue is resolved a
 <br><br>
 
 ***
-## How to apply
+## How to Apply
 
 1. Confirm your app is running in production and generating consistent traffic.
 2. Review your [Integration Health]({{ site.url }}{{ site.baseurl }}{% link api_essentials/integration_health.md %}) status, then download your [API Call Activity Report]({{ site.url }}{{ site.baseurl }}{% link api_essentials/app_performance_metrics.md %}) to investigate further.
@@ -88,7 +88,7 @@ The form explains what each field needs. Two values are worth locating before yo
 <br><br>
 
 ***
-## Temporary increases
+## Temporary Increases
 
 Some work needs headroom for a defined period rather than permanently — a data migration, an archival job, or a one-time backfill. Give an end date on the form rather than requesting an ongoing increase.
 
@@ -96,8 +96,7 @@ A temporary increase is granted with an agreed revert date. On that date your ap
 <br><br>
 
 ***
-## Keeping your increase
-
+## Keep Your Increase
 > **Inactive apps lose their increase, without advance notice.** An app that records zero production API calls for a full calendar month returns to the default limits.
 {: .callout .callout--warning}
 
@@ -109,7 +108,7 @@ Removal is not permanent. If your app becomes active again, apply through the sa
 <br><br>
 
 ***
-## Next steps
+## Next Steps
 - [Rate Limiting]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/rate_limiting.md %}) — headers, `429` handling, and efficiency practices.
 - [Integration Health]({{ site.url }}{{ site.baseurl }}{% link api_essentials/integration_health.md %}) — the status we review with your request.
 - [API Call Activity Report]({{ site.url }}{{ site.baseurl }}{% link api_essentials/app_performance_metrics.md %}) — the 30-day CSV that shows what drives your volume.

--- a/api_essentials/restful_api_concepts.md
+++ b/api_essentials/restful_api_concepts.md
@@ -33,7 +33,7 @@ The Procore API supports the following HTTP verbs as resource methods.
 > **Procore uses PATCH, not PUT, for updates.** Updates are partial — send only the attributes you intend to change. `PUT` is not supported.
 {: .callout .callout--note}
 
-## API Requests and Responses
+## Request and Response Basics
 
 ### Requests
 

--- a/api_essentials/troubleshooting.md
+++ b/api_essentials/troubleshooting.md
@@ -103,7 +103,7 @@ Body (x-www-form-urlencoded):
 <br><br>
 
 ***
-## Rate Limiting
+## Rate Limit Errors
 
 ### 429: Too Many Requests
 
@@ -217,8 +217,7 @@ See [Rate Limiting]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/rate_l
 <br><br>
 
 ***
-## Getting Help
-
+## Get Help
 If you cannot resolve your issue using the guidance above:
 
 1. **Check the status page:** <a href="https://status.procore.com/" target="_blank">status.procore.com</a> for ongoing incidents.

--- a/app_marketplace/marketplace_checklist.md
+++ b/app_marketplace/marketplace_checklist.md
@@ -12,7 +12,7 @@ Before submitting your app for approval, review this Marketplace Approval Checkl
 
 ***
 <details>
-<summary class="collapseListTierOne">Step 1. Confirm You Are a Procore Partner</summary>
+<summary class="collapseListH2">Step 1: Confirm You Are a Procore Partner</summary>
 <p>
     To list on the Marketplace, you must be a <b>full Procore Technology Partner</b> — meaning you have signed the <b>Procore Framework Agreement</b> and <b>Technology Partner Addendum</b> (Step 4 of the partner journey). If you completed that step, you are eligible to list.
     <br><br>
@@ -22,7 +22,7 @@ Before submitting your app for approval, review this Marketplace Approval Checkl
 
 ***
 <details>
-<summary class="collapseListTierOne">Step 2: Validate with a Customer (Recommended)</summary>
+<summary class="collapseListH2">Step 2: Validate with a Customer (Recommended)</summary>
 <p>
     We <b>strongly encourage</b> validating your app with at least one beta or active customer before listing — most partners do this during certification, using their temporary-status production access. Real-world use validates onboarding, functionality, and performance, but is not required to submit.
     <br><br>
@@ -32,7 +32,7 @@ Before submitting your app for approval, review this Marketplace Approval Checkl
 
 ***
 <details>
-<summary class="collapseListTierOne">Step 3: Confirm Your App Is Certified & Production-Ready</summary>
+<summary class="collapseListH2">Step 3: Confirm Production Readiness</summary>
 <p>
     Your app must have passed the <b>Certification Assessment</b> — Procore's production-readiness review completed during the Build, Test & Certify step of the partner journey. If your app is certified and running in production, you've cleared this step; if not, complete certification before listing.
 </p>
@@ -76,7 +76,7 @@ Before submitting your app for approval, review this Marketplace Approval Checkl
 
 ***
 <details>
-<summary class="collapseListTierOne">Step 4: Complete & Verify Your Marketplace Listing</summary>
+<summary class="collapseListH2">Step 4: Complete & Verify Your Marketplace Listing</summary>
 <p>
     With full partner status, the <b>Marketplace Listing</b> section is automatically available in your app in the Developer Portal — there is no separate enablement step. 
     <br><br>
@@ -95,7 +95,7 @@ Before submitting your app for approval, review this Marketplace Approval Checkl
 
 ***
 <details>
-<summary class="collapseListTierOne">Step 5: Submit Your App</summary>
+<summary class="collapseListH2">Step 5: Submit Your App</summary>
 <p>
     When all steps are complete, submit your app via the <b>Marketplace Listing</b> tab in the <a href="https://developers.procore.com/developers" target="_blank">Developer Portal</a>. If you don't see the Marketplace Listing tab, confirm your partner status — the tab is available once you're a full partner.
     <br><br>

--- a/app_marketplace/marketplace_listing_guidelines.md
+++ b/app_marketplace/marketplace_listing_guidelines.md
@@ -72,7 +72,7 @@ Your app's pricing plan is an important part of the submission process, providin
 <br><br>
 
 ***
-## Features
+## Feature Descriptions
 #### **Requirement:** Each feature must be 200 characters or less, no special characters or emojis
 The **Features** section highlights the key functionalities of your app, emphasizing the value it delivers to end-users. Each feature should be clear, specific, and focused on tangible benefits of the app.
 
@@ -105,8 +105,7 @@ This map visually represents how data flows between Procore and the external sys
 <br><br> -->
 
 ***
-## Media
-
+## Media Requirements
 ### Logo
 #### **Requirement:** JPG or PNG, 200x200px 
 Your app icon is one of the first things users notice in the Marketplace, so it should clearly represent your app’s identity. Make sure it's unique, eye-catching, and easy to understand.

--- a/app_marketplace/marketplace_policy.md
+++ b/app_marketplace/marketplace_policy.md
@@ -18,13 +18,15 @@ section_title: Marketplace & Partnership
   ol.roman > li:last-child { margin-bottom: 0; }
 </style>
 
-### Effective: September 30, 2025
+**Effective: September 30, 2025**
+
+## Overview
 
 Welcome to the Procore developer ecosystem! Our goal is to foster a vibrant community where developers can create innovative Applications that connect seamlessly with the Procore Services and enable our Customers to enhance their construction management capabilities. This Developer Policy (“Policy”) outlines the rules and standards aimed at ensuring that any Applications you wish to Commercially Distribute provide a secure, user-friendly, and high-quality experience for all users within the Procore ecosystem. By developing Applications that utilize Procore's APIs you agree to comply with this Procore Developer Policy, as well as the <a href="https://procore.pactsafe.io/legal.html#contract-hymckkfc9" target="_blank">API Terms of Use</a>, which govern the use of our APIs and related services. Please read on to understand how to align your development practices with our expectations and contribute positively to the Procore ecosystem. Terms not defined in this Policy are defined in the API Terms.
 <br><br>
 
 ***
-### 1. Security
+## 1. Security
 
 At Procore, we take the security of our Customers’ data very seriously, and we expect the highest standards from our developers. Your Applications, operating systems, networks, and web services must be configured to operate securely, and all Data must be stored within your system using strong encryption.
 
@@ -48,7 +50,7 @@ Developers and their Applications will not, directly or indirectly:
 <div class="details-bottom-spacing"></div>
 
 ***
-### 2. Use of Data
+## 2. Use of Data
 
 Protecting API Data is paramount at Procore, and it must be for you as well. You are responsible for good API Data stewardship practices, and you have no independent rights to any API Data.
 
@@ -75,7 +77,7 @@ Developers and their Applications will not, directly or indirectly:
 <div class="details-bottom-spacing"></div>
 
 ***
-### 3. User Experience
+## 3. User Experience
 
 Every Application must meet a legitimate business need, respect user privacy, and provide a positive user experience.
 
@@ -94,7 +96,7 @@ Developers and their Applications will not, directly or indirectly:
 <div class="details-bottom-spacing"></div>
 
 ***
-### 4. Business Integrity
+## 4. Business Integrity
 
 While using Procore APIs, developers must agree to respect our business and operate in accordance with appropriate and accepted business conduct.
 
@@ -111,7 +113,7 @@ Developers and their Applications will not, directly or indirectly:
 <div class="details-bottom-spacing"></div>
 
 ***
-### 5. Design
+## 5. Design
 
 Good design is an important part of product development, and we want all users to enjoy a delightful experience. We support developers in their efforts to build applications that provide meaningful and relevant user experiences.
 
@@ -125,7 +127,7 @@ Developers and their Applications will not, directly or indirectly:
 <div class="details-bottom-spacing"></div>
 
 ***
-### 6. Legal Compliance & Safety
+## 6. Legal Compliance & Safety
 
 Applications must not create unsafe environments or hardships for Customers. Each Application must comply with all applicable laws and legal requirements in all locations where it is made available.
 
@@ -149,13 +151,13 @@ Developers and their Applications will not, directly or indirectly:
 <div class="details-bottom-spacing"></div>
 
 ***
-### 7. Data Breach
+## 7. Data Breach
 
 If API Data is breached, exposed, exploited, or otherwise compromised through your Application or company, you must immediately inform all affected Customers and Procore in accordance with the API Terms. Please contact us at <a href="mailto:security@procore.com">security@procore.com</a> immediately.
 <br><br>
 
 ***
-### 8. Compliance and Consequences of Violations
+## 8. Compliance and Consequences of Violations
 
 Developers who wish to Commercially Distribute their Applications are required to comply with this Policy, as well as all other Procore guidelines and policies, including the API Terms. We expect developers to exercise good judgment, build and submit Applications with reasonable work-related purposes, and ensure they are a good fit for Procore Customers. You will also notify us immediately if you materially change the function of or discontinue your Application.
 

--- a/app_marketplace/procore_partner_overview.md
+++ b/app_marketplace/procore_partner_overview.md
@@ -13,7 +13,7 @@ Anyone can sign up, explore our APIs, and start building. When you're ready to r
 <br><br>
 
 ***
-## Start Building Today
+## Build Before Partnering
 You don't need to be a Technology Partner to start building. Our developer platform is **fully self-service**, allowing you to explore and build at your own pace.
 
 - **<a href="https://developers.procore.com/signup" target="_blank">Create a Developer Account</a>** to access the Developer Portal and your Sandbox Sandbox
@@ -111,7 +111,7 @@ Not sure which verification path is right for you? See [Verification & Productio
 <!-- **For existing partners:** Later in FY26, Procore will introduce a recertification process to validate that current Marketplace listings meet updated standards. This process will be streamlined to recognize the operational history of existing partners. -->
 
 ***
-## Ready to Get Started?
+## Apply to the Partner Program
 
 **Want to become a Technology Partner?** Submit your application and our team will assess your solution for complementarity, strategic alignment, and ecosystem eligibility.
 
@@ -126,12 +126,12 @@ Not sure which verification path is right for you? See [Verification & Productio
 <br><br>
 
 ***
-## Want to Review the Partner Agreement Before Applying?
+## Partner Agreement and Terms
 We recommend reviewing our <a target="_blank" href="https://downloads.ctfassets.net/8pep15rt0kef/3cqMPZK5V9dt5VM9WvL4hA/9489b69ecdf426bd957f7fdb2ce541d6/Procore_Partner_Program_Guide.pdf">Partner Program Guide</a>, <a target="_blank" href="https://assets.ctfassets.net/8pep15rt0kef/3p5N8hUCPqxO2d7qIfym0B/05f433ed5d2d4a99d1a1eea8364c6895/partner-framework-agreement.pdf">Terms</a>, and <a target="_blank" href="https://assets.ctfassets.net/8pep15rt0kef/Owy2JJPZE8QDSaxL2QXAj/8896c4afe4136f9cd2f14111e29208ac/Procore_Partner_Code_of_Conduct.pdf">Partner Code of Conduct</a> early in your journey. The Program Guide outlines what to expect regarding partner tiers, benefits, and associated fees; the Partner Agreements detail the legal terms you'll need to agree to before listing your app on the Marketplace; and the Code of Conduct sets the standards every partner is expected to uphold. Familiarizing yourself with these early on can help you plan your integration and go-to-market strategy more effectively.
 <br><br>
 
 ***
-## Explore Our Resources
+## See Also
 - <a target="_blank" href="https://docs.google.com/document/d/19kHjHF4z-5ajDs6B5o27FEupgKVN7vbN9ds0RKl45Wc/edit?tab=t.0#heading=h.l90ieu5n7004">Technology Program FAQs</a>
 - <a target="_blank" href="https://www.procore.com/partners/documents">Procore Partner Program Documents</a>
 - [Help & Learning Center]({{ site.url }}{{ site.baseurl }}{% link overview/help_and_learning_center.md %})

--- a/app_marketplace/update_your_marketplace_app.md
+++ b/app_marketplace/update_your_marketplace_app.md
@@ -14,7 +14,7 @@ This guide covers how to manage updates to your app, view key metrics, and imple
 
 ***
 
-## Manage Your App
+## Update Your App
 You can update your app’s functionality, features, or Marketplace Listing at any time through the <a href="https://developers.procore.com/developers" target="_blank">Procore Developer Portal</a>. Note that some changes may require approval from the Marketplace team.
 
 If you're unable to access the app in the Developer Portal, see [Managing App Collaborators]({{ site.url }}{{ site.baseurl }}{% link building_applications/building_apps_manage_collabs.md %}) to check your role or request access.
@@ -110,7 +110,7 @@ Key metrics include:
 ***
 <div class="details-bottom-spacing"></div>
 
-## Marketing & Growing Your App
+## Market and Grow Your App
 Publishing your app on the Procore Marketplace is just the first step toward scaling adoption and maximizing its impact. This section focuses on the different aspects of growing and maintaining your app, as well as some of the self-service marketing activities.
 
 ### Leverage Procore’s Marketing Guides

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,6 +1,6 @@
 body {
     font-family: Inter, Noto, Arial, sans-serif;
-    background-color: #f1f3f3;
+    background-color: #ffffff;
     color: #202020;
     font-size: 14px;
     line-height: 20px;
@@ -68,14 +68,13 @@ body {
     flex: 1 1 0%;
   }
 
+  /* No card. The page is a single white surface (Stripe-style), so the content
+     column is positioned by the gaps on <article> rather than by centering a
+     floating panel — see the padding on `article` in nav.css. */
   article section {
     max-width: 1200px;
-    /* Center the container on the FULL page (nav space counted), clamped so it never crowds the nav */
-    margin-left: max(24px, calc(50vw - 940px));
+    margin-left: 0;
     margin-right: auto;
-    background-color: white;
-    border-radius: 4px;
-    box-shadow: rgb(0 0 0 / 20%) 0px 1px 2px, rgb(0 0 0 / 10%) 0px 1px 3px;
   }
 
   article h1 {

--- a/assets/css/nav.css
+++ b/assets/css/nav.css
@@ -117,26 +117,25 @@ nav:not(.toc) {
   height: 38px;
   margin-bottom: 4px;
   padding: 0 34px 0 36px;
-  border: 1px solid #d9dce1;
+  border: 1px solid #acb5b9;
   border-radius: 8px;
   background-color: #fff;
   background-repeat: no-repeat;
   background-position: 12px center;
   background-size: 15px 15px;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%238a9099' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='11' r='7'/%3E%3Cline x1='21' y1='21' x2='16.65' y2='16.65'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23232729' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='11' r='7'/%3E%3Cline x1='21' y1='21' x2='16.65' y2='16.65'/%3E%3C/svg%3E");
   color: #232729;
   font-size: 14px;
-  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  transition: border-color 0.15s ease;
 }
 
 #search-input::placeholder {
-  color: #8a9099;
+  color: #5e696e;
 }
 
 #search-input:focus {
   outline: none;
-  border-color: #006ddf;
-  box-shadow: 0 0 0 3px rgba(0, 109, 223, 0.15);
+  border: 2px solid #006ddf;
 }
 
 .search-clear {
@@ -290,7 +289,9 @@ nav dd {
 nav dd a {
   display: block;
   padding: 7px 14px;
-  color: #4a4f54;
+  /* Same black as the section titles (nav dt) so both levels of the sidebar
+     read at the same colour weight. */
+  color: #232729;
   text-decoration: none;
   border-radius: 0 6px 6px 0;
   white-space: nowrap;

--- a/assets/css/nav.css
+++ b/assets/css/nav.css
@@ -4,19 +4,103 @@
    the original behaviour, left intact for now)
    ============================================================ */
 
-article {
-  padding: 48px 48px 48px 0; /* no left padding so the content card can center on the full page (past the nav) */
+/* Sidebar width. Referenced again by toc.css, which has to pin the same value
+   as a flex-basis so the rail cannot squeeze the nav — keep it a variable so
+   the two cannot drift apart. */
+:root {
+  --nav-width: 400px;
+  --page-margin: 100px;
+  /* One divider colour for the layout: the sidebar's trailing edge and the two
+     page-frame rules. */
+  --rule-color: rgb(217, 217, 217);
+
+  /* Selected-state pair for the sidebar, per design 2026-08-19. The previous
+     #006ddf on #d6e8fb measured 3.95:1 — under the 4.5:1 AA floor for 14px
+     text. This pair measures 7.02:1 (AA and AAA), and #0F45A2 on white is
+     8.77:1, so the same ink is safe on both backgrounds. */
+  --nav-selected-ink: #0f45a2;
+  --nav-selected-fill: #dae7fa;
+
+  /* Selected-item accent rule. Shared with the "On this page" rail in toc.css
+     so the sidebar and the rail mark the current item identically — declared
+     once here rather than as a literal in each file, so they cannot drift.
+     4px is Procore's AnchorSection value (core 12.49.0). */
+  --selected-rule-width: 4px;
 }
 
-nav {
-  width: 340px;
+/* Page frame — a gutter at each screen edge with the rule on its INNER edge,
+   so the line sits against the content rather than out at the page boundary.
+   Borders live on <body> (the flex row holding nav + article), which puts them
+   exactly at the margin/content boundary and runs them the full content
+   height. */
+body {
+  margin-left: var(--page-margin);
+  margin-right: var(--page-margin);
+  border-left: 1px solid var(--rule-color);
+  border-right: 1px solid var(--rule-color);
+}
+
+/* Column gaps, measured from docs.stripe.com at a 1600px viewport: left nav →
+   prose 113px and a 128px right margin. The nav→prose gap is the source of
+   truth for column spacing — prose → TOC matches it via --toc-gap in toc.css.
+   The left value carries that gap now that the content card is gone and there
+   is no panel to centre. */
+article {
+  padding: 48px 128px 48px 113px;
+}
+
+/* ---------------- Responsive ladder ----------------
+   The content column is the focal point and is protected for as long as
+   possible: it is not reduced until mobile, when there is nothing left to
+   spend. Everything else is sacrificed first, in this order:
+
+     1. The page frame  — margins + rules. Genuinely wide monitors only; below
+        that it is dead space, so it goes first and goes completely.
+     2. The column gutters — collapsed in steps, which walks the content left
+        toward the nav rather than narrowing it.
+     3. The rail — the first whole column to go, once no whitespace is left.
+     4. The nav — off-canvas at the mobile breakpoint, last of all.
+
+   --toc-gap steps in lockstep with the left gutter (see toc.css) so the
+   nav→prose and prose→rail gaps stay equal the whole way down. */
+
+/* The frame earns its keep only on a genuinely wide monitor. */
+@media (max-width: 2100px) {
+  :root {
+    --page-margin: 0px;
+  }
+
+  body {
+    border-left: 0;
+    border-right: 0;
+  }
+}
+
+/* Whitespace next — pull the content left instead of narrowing it. */
+@media (max-width: 1700px) {
+  article {
+    padding: 48px 64px;
+  }
+}
+
+@media (max-width: 1400px) {
+  article {
+    padding: 48px 32px;
+  }
+}
+
+/* :not(.toc) — the "On this page" rail is also a <nav>, and without this it
+   inherits the sidebar's width, 100vh height, 32px/20px padding and
+   right border. */
+nav:not(.toc) {
+  width: var(--nav-width);
   box-sizing: border-box;
   height: 100vh;
   position: sticky;
   top: 0;
   overflow-y: auto;
   padding: 32px 20px;
-  border-right: 1px solid rgb(217, 217, 217);
+  border-right: 1px solid var(--rule-color);
   font-size: 14px;
   line-height: 1.4;
 }
@@ -169,7 +253,7 @@ nav dt:hover {
 }
 
 nav dt.active {
-  color: #006ddf;
+  color: var(--nav-selected-ink);
 }
 
 nav dt .icon {
@@ -184,7 +268,7 @@ nav dt .icon.open {
 }
 
 nav dt.active .icon {
-  color: #006ddf;
+  color: var(--nav-selected-ink);
 }
 
 /* ---------------- Section items ---------------- */
@@ -197,7 +281,10 @@ dl.col_content {
 nav dd {
   margin: 0;
   padding: 0;
-  border-left: 2px solid #ededed;
+  /* Transparent rather than removed: the expanded-section rail is gone, but the
+     width is still reserved so items don't shift horizontally, and the current
+     page keeps its accent via `nav dd.active` below. */
+  border-left: var(--selected-rule-width) solid transparent;
 }
 
 nav dd a {
@@ -218,12 +305,12 @@ nav dd a:hover {
 }
 
 nav dd.active {
-  border-left-color: #006ddf;
+  border-left-color: var(--nav-selected-ink);
 }
 
 nav dd.active a {
-  color: #006ddf;
-  background-color: #d6e8fb;
+  color: var(--nav-selected-ink);
+  background-color: var(--nav-selected-fill);
   font-weight: 500;
 }
 
@@ -251,8 +338,13 @@ nav dd.active a {
   background: #3a3f43;
 }
 
+/* hideNav() strips the desktop gutters for the embedded view. Those gutters
+   used to be optional because the white content card supplied its own inset
+   against the grey page; now that the page is a single white surface, zeroing
+   the padding would run body text flush into the iframe edge. Keep a modest
+   symmetric inset instead — the host page supplies the outer chrome. */
 article.no-padding {
-  padding: 0;
+  padding: 24px 48px;
 }
 
 section.full-width {
@@ -296,13 +388,21 @@ html.nav-locked {
     padding: 0;
   }
 
+  /* The page frame costs 200px of width — too much once the nav is a drawer. */
+  body {
+    margin-left: 0;
+    margin-right: 0;
+    border-left: 0;
+    border-right: 0;
+  }
+
   /* Mobile: cancel the desktop page-centering offset — content is full-width in the drawer layout */
   article section {
     margin-left: 0;
   }
 
   /* Nav becomes a left slide-in drawer */
-  nav {
+  nav:not(.toc) {
     position: fixed;
     top: 0;
     left: 0;

--- a/assets/css/toc.css
+++ b/assets/css/toc.css
@@ -1,0 +1,237 @@
+/* ============================================================
+   On this page — in-page H2 navigation rail (AGX-7204)
+
+   Markup is rendered at runtime by assets/js/toc.js. The layout
+   only switches on when toc.js adds `.has-toc` to <body>, so the
+   ~30 pages with too few headings keep the original single-column
+   layout untouched.
+
+   Two display modes matter:
+     - standalone  — left nav (--nav-width) + content + rail
+     - embedded    — ?hideNav=true strips the left nav entirely
+                     (see hideNav() in nav.js); content + rail only.
+       This is the production reader experience on
+       developers.procore.com, where the rail is the ONLY in-page
+       navigation available.
+   ============================================================ */
+
+/* Width matches docs.stripe.com's TOC text column (its RightPane is 250px with
+   48px of left padding).
+
+   The gap does NOT follow Stripe. The nav→content gap is the source of truth
+   for column spacing on this site, so content→TOC uses the same 113px that
+   `article`'s left padding sets in nav.css — the reading column sits in equal
+   gutters rather than being pushed against the rail. Keep the two in step: if
+   one changes, change both. */
+:root {
+  --toc-width: 202px;
+  --toc-gap: 113px;
+  /* Drops the rail so "On this page" starts level with the h1's text rather
+     than with its box. Mirrors the 48px top padding on `article h1` in
+     main.css — if that padding changes, change this with it. Purely vertical:
+     the rail's column position and the prose width are untouched. */
+  --toc-offset: 48px;
+
+  /* Procore AnchorSection palette (core 12.49.0) — see .toc__link below. */
+  --toc-rule-rest: #e3e6e8;
+  --toc-rule-hover: #919ca1;
+  --toc-rule-active: #232729;
+  --toc-fill: #e3e6e8;
+}
+
+/* ---------------- Layout ---------------- */
+
+body.has-toc article {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--toc-gap);
+  /* <article> is itself a flex item of <body>. Its default min-width:auto
+     pins it to its content width, so without this the third column pushes the
+     page into horizontal scroll instead of the content column giving way. */
+  min-width: 0;
+}
+
+/* min-width:0 lets the content column shrink; without it a wide table or
+   code block refuses to give the rail its width and pushes it off-screen. */
+body.has-toc article section {
+  flex: 1 1 auto;
+  min-width: 0;
+  margin-left: 0;
+  margin-right: 0;
+}
+
+/* Flex items shrink by default, and the rail widens <article>'s min-content
+   width. Without this the left nav gives up its own width to make room —
+   it collapsed to ~176px on pages with wide tables. --nav-width is defined in
+   nav.css; this must stay pinned to the same value. */
+body.has-toc nav:not(.toc) {
+  flex: 0 0 var(--nav-width);
+}
+
+/* With the nav pinned and a third column in play there is no spare width left
+   to donate to an oversized table, so tables scroll inside the content column
+   rather than stretching the page. Scoped to .has-toc so the ~30 pages without
+   a rail keep their current behaviour exactly. */
+body.has-toc main table {
+  display: block;
+  width: fit-content;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+/* Embedded mode. `section.full-width` forces width:100%, which combined with
+   the inherited margin-left overflowed the frame by 24px even before the rail
+   existed — that is the horizontal scrollbar visible on the live site. Letting
+   flex size the column fixes the overflow and makes room for the rail. */
+body.has-toc section.full-width {
+  max-width: none;
+  min-width: 0;
+  width: auto;
+  margin-left: 0;
+}
+
+
+/* ---------------- The rail ---------------- */
+
+.toc {
+  flex: 0 0 var(--toc-width);
+  width: var(--toc-width);
+  box-sizing: border-box;
+  /* Explicit, so nothing from the sidebar's <nav> rules can reintroduce a
+     gutter or a divider here. */
+  padding: 0;
+  border: 0;
+  margin-top: var(--toc-offset);
+  position: sticky;
+  top: 48px;
+  /* Longest page in the vault has 29 H2s, so the rail has to scroll itself
+     rather than run off the bottom of the viewport. */
+  max-height: calc(100vh - 96px);
+  overflow-y: auto;
+  /* 14px matches the sidebar nav, so the two navigations read at the same
+     scale rather than the rail looking like fine print. */
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.toc[hidden] {
+  display: none;
+}
+
+/* Sentence case, same 14px as the entries. Weight and colour do the work of
+   marking it as the heading — no uppercasing, and no letter-spacing, which
+   only ever existed to open up the all-caps setting. */
+.toc__title {
+  font-size: 14px;
+  font-weight: 600;
+  /* Overrides the 0.15px tracking `article h2` would otherwise apply here. */
+  letter-spacing: normal;
+  color: #232729;
+  margin: 0 0 10px;
+  padding: 0;
+  line-height: 20px;
+}
+
+.toc__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.toc__item {
+  margin: 0;
+}
+
+/* States lifted from Procore's own AnchorSection component (core 12.49.0), as
+   used for the in-page section nav on the Project Webhooks tool — the closest
+   thing we have to a house pattern for exactly this control. Values read off
+   the live stylesheet:
+     rest    4px #E3E6E8 rule, no fill
+     hover   4px #919CA1 rule, #E3E6E8 fill
+     active  4px #232729 rule, #E3E6E8 fill, 600 weight
+   Colour alone never carries state — the rule darkens AND a fill appears, so
+   it survives greyscale and low-vision viewing. */
+.toc__link {
+  display: block;
+  padding: 6px 8px;
+  /* --selected-rule-width is declared in nav.css and shared with the sidebar's
+     `nav dd`, so both navigations mark the current item at the same weight. */
+  border-left: var(--selected-rule-width) solid var(--toc-rule-rest);
+  border-radius: 0 4px 4px 0;
+  background-color: transparent;
+  color: #232729;
+  text-decoration: none;
+  transition: background-color 0.12s ease, border-color 0.12s ease;
+}
+
+/* Only the fill and the rule change on hover — the label colour is deliberately
+   held. The explicit `color` is load-bearing: the global `a:hover` in main.css
+   is (0,1,1) and outranks `.toc__link` (0,1,0), so without restating it here
+   the label turns link-blue on hover. */
+.toc__link:hover {
+  border-left-color: var(--toc-rule-hover);
+  background-color: var(--toc-fill);
+  color: #232729;
+}
+
+.toc__link:focus-visible {
+  outline: 2px solid #006ddf;
+  outline-offset: -2px;
+}
+
+/* After :hover deliberately — same specificity, so source order wins and the
+   active item does not shift under the cursor. Matches AnchorSection, whose
+   active:hover rule is identical to its active rule. */
+.toc__link[aria-current="true"] {
+  border-left-color: var(--toc-rule-active);
+  background-color: var(--toc-fill);
+  font-weight: 600;
+}
+
+/* ---------------- Scroll targets ---------------- */
+
+/* Keeps a jumped-to heading clear of the top edge instead of flush against it.
+   Harmless on pages with no rail, so it is not scoped to .has-toc. */
+main h2,
+main h3,
+main h4,
+main summary.collapseListH2 {
+  scroll-margin-top: 24px;
+}
+
+/* ---------------- Narrow viewports ----------------
+   Steps in lockstep with the left gutter in nav.css so the nav→prose and
+   prose→rail gaps stay equal as they collapse. See the responsive ladder
+   comment there for the ordering rationale. */
+
+@media only screen and (max-width: 1700px) {
+  :root {
+    --toc-gap: 64px;
+  }
+}
+
+@media only screen and (max-width: 1400px) {
+  :root {
+    --toc-gap: 32px;
+  }
+}
+
+/* The rail is the first whole column to go — once the gutters have bottomed
+   out it is the cheapest thing left to spend, and dropping it returns ~234px
+   to the prose. 1200px per design; kept clear of the nav drawer breakpoint
+   (1100px) so the two structural transitions never land on the same resize
+   step. Note the prose is at its narrowest (~465px) just above this
+   breakpoint, where the rail is still holding its column. */
+@media only screen and (max-width: 1200px) {
+  .toc {
+    display: none;
+  }
+
+  body.has-toc article {
+    display: block;
+  }
+
+  body.has-toc article section {
+    margin-left: 0;
+  }
+}

--- a/assets/js/toc.js
+++ b/assets/js/toc.js
@@ -242,6 +242,16 @@
       revealTarget(target);
       target.scrollIntoView({ behavior: scrollBehavior(), block: "start" });
 
+      // preventDefault() suppresses the browser's native fragment navigation,
+      // which also moves focus and resets the sequential-navigation start point
+      // to the target. Without restoring that, a keyboard or screen-reader user
+      // jumps the viewport but keeps focus in the rail, and tabbing continues
+      // from the rail rather than the section they just chose.
+      // tabindex="-1" makes a non-interactive heading programmatically
+      // focusable; preventScroll leaves the smooth scroll above undisturbed.
+      target.setAttribute("tabindex", "-1");
+      target.focus({ preventScroll: true });
+
       // replaceState, not pushState. An iframe shares its session history with
       // the host page, so pushing an entry per jump makes the reader's Back
       // button crawl backwards through in-page anchors instead of leaving

--- a/assets/js/toc.js
+++ b/assets/js/toc.js
@@ -1,0 +1,337 @@
+/* ============================================================
+   On this page — in-page H2 navigation rail (AGX-7204)
+
+   Builds a single-tier list of the page's H2s, keeps the current
+   section highlighted while scrolling, and takes over in-page
+   anchor clicks.
+
+   The click handling is not cosmetic. _layouts/default.html sets
+   <base target="_parent">, which resolves every bare <a href="#x">
+   into the PARENT browsing context. On developers.procore.com the
+   docs are iframed, so clicking an in-page anchor navigates the
+   host page to procore.github.io/...?hideNav=true#x — the reader
+   is thrown out of the frame and stranded on a navless page on
+   another domain. That affects the ~184 in-content anchors that
+   already exist, not just this rail, so the handler is bound to
+   all of <main> rather than to the rail alone.
+   ============================================================ */
+
+(function () {
+  "use strict";
+
+  // --- What earns a rail -------------------------------------------------
+  //
+  // Page rule: three or more indexable H2s. Below that the rail is a label,
+  // not navigation — and since "## Overview" is the house-standard intro
+  // heading on 76 pages, a two-entry rail is almost always "Overview plus one
+  // thing" in exchange for 272px of horizontal space.
+  //
+  // Deliberately NOT gated on page length. Measured against the live corpus,
+  // every page clears 1.5 viewports (1.75–2.37 sampled, including a 241-word
+  // one) because the card layout inflates height independently of content, so
+  // a length test never fires. Section count is also the better signal on its
+  // own: /introduction is 413 words with 7 sections and needs navigation,
+  // while /building-apps-install-arch is 749 words with 2 and has none.
+  var MIN_HEADINGS = 3;
+
+  // Section rule: the rail indexes what the page teaches. Two classes of
+  // heading are not that, and both are excluded.
+  //
+  //   1. Injected chrome — put on the page by an include, identical wherever
+  //      it appears, not authored for this page. Test: would this heading read
+  //      the same on every page that has it?
+  //   2. Exit ramps — sections whose content is links off this page. Test:
+  //      does it describe what this page covers, or where to go next? The rail
+  //      answers the first question; an exit ramp is the door out, not a room.
+  //
+  // Matched case-insensitively. Authors can exclude anything else per-heading
+  // with a kramdown IAL: {: .toc-exclude}
+  // The corpus was normalised to house headings on 2026-08-18, so each entry
+  // here maps to exactly one canonical spelling rather than chasing variants.
+  // Add to this list only alongside a heading standard — a new spelling is a
+  // content problem, not a matching problem. One-offs use {: .toc-exclude}.
+  var EXCLUDED_TITLES = [
+    "need help?",            // chrome — _includes/need_help_section.md (5)
+    "see also",              // exit ramp — lateral related reading (48)
+    "next steps",            // exit ramp — forward sequence (6)
+    "related documentation"  // guide set navigator, top of multi-page guides (3)
+  ];
+
+  // Distance from the top of the viewport at which a heading becomes "current".
+  var ACTIVE_OFFSET = 96;
+
+  document.addEventListener("DOMContentLoaded", function () {
+    var main = document.querySelector("main");
+    var rail = document.getElementById("toc");
+    if (!main || !rail) return;
+
+    // Baseline protection, applied whether or not this page gets a rail:
+    // an explicit target on the element beats <base target>, so even if the
+    // click handler below never runs, anchors scroll in place instead of
+    // breaking the page out of its iframe.
+    forceSelfTarget(main);
+
+    var headings = collectHeadings(main);
+
+    // Bind clicks regardless — pages with too few headings for a rail still
+    // have prose cross-references that need the same fix.
+    bindAnchorClicks(main, rail);
+
+    if (headings.length < MIN_HEADINGS) return;
+
+    var links = render(rail, headings);
+    forceSelfTarget(rail);
+    document.body.classList.add("has-toc");
+    rail.hidden = false;
+
+    bindScrollSpy(rail, headings, links);
+  });
+
+  /* ---------------- Building the list ---------------- */
+
+  // A collapsible section's title is a <summary class="collapseListH2">, not an
+  // <h2> — deliberately, because a real heading would break the disclosure
+  // widget. Per the house collapsible taxonomy that class IS the section level,
+  // so it is indexed as a peer of h2. collapseListTierOne is a step or example
+  // *inside* a section and is never indexed. querySelectorAll returns document
+  // order, so the two kinds interleave correctly on mixed pages.
+  var HEADING_SELECTOR = "h2, summary.collapseListH2";
+
+  function collectHeadings(main) {
+    var found = [];
+    var nodes = main.querySelectorAll(HEADING_SELECTOR);
+
+    for (var i = 0; i < nodes.length; i++) {
+      var node = nodes[i];
+      var label = headingLabel(node);
+      if (!label) continue;
+      if (isExcluded(node, label)) continue;
+
+      // kramdown's auto_ids gives every heading an id and all 640 H2s in this
+      // repo are kramdown-generated, so this is a fallback for hand-authored
+      // HTML headings rather than the normal path.
+      if (!node.id) node.id = uniqueId(slugify(label));
+
+      found.push(node);
+    }
+
+    return found;
+  }
+
+  // A <summary> holds the section title AND a .collapseSubhead description.
+  // textContent would return both, producing a paragraph-long rail entry, so
+  // the description is stripped from a clone before reading the label.
+  function headingLabel(node) {
+    if (node.tagName !== "SUMMARY") {
+      return (node.textContent || "").trim();
+    }
+
+    var clone = node.cloneNode(true);
+    var subhead = clone.querySelector(".collapseSubhead");
+    if (subhead && subhead.parentNode) {
+      subhead.parentNode.removeChild(subhead);
+    }
+    return (clone.textContent || "").replace(/\s+/g, " ").trim();
+  }
+
+  // Jumping to a section inside a closed <details> would otherwise land the
+  // reader on a collapsed accordion with nothing visible under the title.
+  function revealTarget(el) {
+    var node = el;
+    while (node && node !== document.body) {
+      if (node.tagName === "DETAILS" && !node.open) {
+        node.open = true;
+      }
+      node = node.parentNode;
+    }
+  }
+
+  function isExcluded(node, label) {
+    if (node.classList && node.classList.contains("toc-exclude")) return true;
+
+    var normalized = label.toLowerCase().replace(/\s+/g, " ").trim();
+    for (var i = 0; i < EXCLUDED_TITLES.length; i++) {
+      if (normalized === EXCLUDED_TITLES[i]) return true;
+    }
+    return false;
+  }
+
+  function slugify(text) {
+    return (
+      text
+        .toLowerCase()
+        .replace(/[^a-z0-9\s-]/g, "")
+        .trim()
+        .replace(/\s+/g, "-") || "section"
+    );
+  }
+
+  function uniqueId(base) {
+    var id = base;
+    var n = 2;
+    while (document.getElementById(id)) {
+      id = base + "-" + n;
+      n++;
+    }
+    return id;
+  }
+
+  function render(rail, headings) {
+    var title = document.createElement("h2");
+    title.className = "toc__title";
+    title.id = "toc-title";
+    title.textContent = "On this page";
+
+    var list = document.createElement("ul");
+    list.className = "toc__list";
+
+    var links = [];
+
+    for (var i = 0; i < headings.length; i++) {
+      var item = document.createElement("li");
+      item.className = "toc__item";
+
+      var link = document.createElement("a");
+      link.className = "toc__link";
+      link.href = "#" + headings[i].id;
+      link.target = "_self";
+      link.textContent = headingLabel(headings[i]);
+
+      item.appendChild(link);
+      list.appendChild(item);
+      links.push(link);
+    }
+
+    rail.setAttribute("aria-labelledby", "toc-title");
+    rail.appendChild(title);
+    rail.appendChild(list);
+
+    return links;
+  }
+
+  /* ---------------- Anchor clicks ---------------- */
+
+  function forceSelfTarget(root) {
+    var anchors = root.querySelectorAll('a[href^="#"]');
+    for (var i = 0; i < anchors.length; i++) {
+      anchors[i].setAttribute("target", "_self");
+    }
+  }
+
+  function bindAnchorClicks(main, rail) {
+    document.addEventListener("click", function (event) {
+      if (event.defaultPrevented || event.button !== 0) return;
+      if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+
+      var link = closestAnchor(event.target);
+      if (!link) return;
+      if (!main.contains(link) && !rail.contains(link)) return;
+
+      var href = link.getAttribute("href");
+      if (!href || href === "#") return;
+
+      var id = decodeURIComponent(href.slice(1));
+      var target = document.getElementById(id);
+
+      // Unknown fragment — leave it to the browser rather than swallowing it.
+      if (!target) return;
+
+      event.preventDefault();
+      // Open before measuring — expanding a <details> changes layout height,
+      // so scrolling first would land at a stale offset.
+      revealTarget(target);
+      target.scrollIntoView({ behavior: scrollBehavior(), block: "start" });
+
+      // replaceState, not pushState. An iframe shares its session history with
+      // the host page, so pushing an entry per jump makes the reader's Back
+      // button crawl backwards through in-page anchors instead of leaving
+      // the docs.
+      if (window.history && window.history.replaceState) {
+        window.history.replaceState(null, "", "#" + id);
+      }
+    });
+  }
+
+  function scrollBehavior() {
+    if (!window.matchMedia) return "auto";
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth";
+  }
+
+  function closestAnchor(node) {
+    while (node && node !== document) {
+      if (node.tagName === "A" && (node.getAttribute("href") || "").charAt(0) === "#") {
+        return node;
+      }
+      node = node.parentNode;
+    }
+    return null;
+  }
+
+  /* ---------------- Active section ---------------- */
+
+  function bindScrollSpy(rail, headings, links) {
+    var ticking = false;
+
+    function update() {
+      var currentId = headings[0].id;
+
+      for (var i = 0; i < headings.length; i++) {
+        if (headings[i].getBoundingClientRect().top <= ACTIVE_OFFSET) {
+          currentId = headings[i].id;
+        } else {
+          break;
+        }
+      }
+
+      // At the bottom of the page the last section may be too short to ever
+      // cross the offset, so it would never highlight without this.
+      if (window.innerHeight + window.pageYOffset >= document.body.scrollHeight - 2) {
+        currentId = headings[headings.length - 1].id;
+      }
+
+      setActive(rail, links, currentId);
+      ticking = false;
+    }
+
+    function onScroll() {
+      if (ticking) return;
+      ticking = true;
+      window.requestAnimationFrame(update);
+    }
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll, { passive: true });
+    update();
+  }
+
+  function setActive(rail, links, id) {
+    for (var i = 0; i < links.length; i++) {
+      var link = links[i];
+      var isActive = link.getAttribute("href") === "#" + id;
+
+      if (isActive) {
+        if (link.getAttribute("aria-current") !== "true") {
+          link.setAttribute("aria-current", "true");
+          keepVisible(rail, link);
+        }
+      } else {
+        link.removeAttribute("aria-current");
+      }
+    }
+  }
+
+  // Scrolls the rail's own overflow, never the page — long pages would
+  // otherwise fight the reader for control of the scroll position.
+  function keepVisible(rail, link) {
+    if (rail.scrollHeight <= rail.clientHeight) return;
+
+    var top = link.offsetTop;
+    var bottom = top + link.offsetHeight;
+
+    if (top < rail.scrollTop) {
+      rail.scrollTop = top;
+    } else if (bottom > rail.scrollTop + rail.clientHeight) {
+      rail.scrollTop = bottom - rail.clientHeight;
+    }
+  }
+})();

--- a/best_practices/date_time.md
+++ b/best_practices/date_time.md
@@ -135,8 +135,7 @@ For example, the ISO-3166 Alpha-2 code for the United States is `US`, and the co
 <br><br>
 
 ***
-## Working with Time Zones
-
+## Work with Time Zones
 Setting or updating a Project's time zone using the Procore API requires that specific string values are properly applied for the `time_zone` attribute.
 If the string value provided does not match exactly what the Procore API is expecting, a `422 Unprocessable Entity` error will be returned.
 

--- a/best_practices/secure_file_access_tips.md
+++ b/best_practices/secure_file_access_tips.md
@@ -10,12 +10,10 @@ section_title: "Product Guides: Documents & Files"
 
 Below are some valuable tips for working with secure file access and the Procore API.
 
-## Handling URL Schema Changes
-
+## Handle URL Schema Changes
 As indicated in the ["File Link URL Schema Change"]({{ site.url }}{{ site.baseurl }}{% link announcements/overview.md %}#file-link-url-schema-change) announcement posted 06/28/2023, developers should not assume any particular hostnames for download links because they can change in future, both due to Procore backend changes as well as changes from our cloud service partner, Amazon Web Services.
 
-## Passing the Bearer Token for File Downloads
-
+## Pass the Bearer Token
 As described in the ["Bearer Token to be Required for File Access Authorization"]({{ site.url }}{{ site.baseurl }}{% link announcements/overview.md %}#bearer-token-to-be-required-for-file-access-authorization) announcement posted 06/10/2022, we require developers to include the Procore Bearer Token for accessing any file or document URL.
 One important detail is that files are not necessarily served directly by those URLs.
 For example, clients currently get redirected to our cloud service partner, Amazon Web Services, to actually fetch file content.
@@ -131,8 +129,7 @@ public class DownloaderApp {
 
 ```
 
-## Testing Your Integration
-
+## Test Your Integration
 This functionality is available in Monthly and Developer Sandboxes.
 
 ## See Also

--- a/building_applications/building_agentic_apps.md
+++ b/building_applications/building_agentic_apps.md
@@ -45,7 +45,7 @@ Agentic components are authored in the same manifest and versioning flow as the 
 <br><br>
 
 ***
-## Next steps
+## Next Steps
 - [Choose an App Type]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/building_apps_app_types.md %}) — how Agentic fits among the app families.
 - [Create an App]({{ site.url }}{{ site.baseurl }}{% link building_applications/building_apps_create_new.md %}) — start an app and its manifest.
 - <a href="https://v2.support.procore.com/product-manuals/procore-ai/tutorials/about-procore-ai" target="_blank">About Procore AI</a> — the customer experience your capabilities surface in.

--- a/building_applications/building_apps_create_new.md
+++ b/building_applications/building_apps_create_new.md
@@ -60,7 +60,7 @@ For more information on app versions, see [App Versioning and Update Notificatio
 <br><br>
 
 ***
-## Explore Our Resources
+## See Also
 - [Managing App Collaborators]({{ site.url }}{{ site.baseurl }}{% link building_applications/building_apps_manage_collabs.md %})
 - [Available App Types]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/building_apps_app_types.md %})
 - [Managing App Versions & Update Notifications]({{ site.url }}{{ site.baseurl }}{% link building_applications/building_apps_promote_manifest.md %})

--- a/building_applications/building_apps_manage_collabs.md
+++ b/building_applications/building_apps_manage_collabs.md
@@ -18,7 +18,7 @@ Each role has a defined set of permissions for actions that can be taken by a te
 
 ***
 <details>
-  <summary class="collapseListTierOne">Collaborator Permission Overview</summary>
+  <summary class="collapseListH2">Collaborator Permissions</summary>
     <p>
     Before inviting team members to collaborate on your app, it's important to understand the roles available and the actions each can perform within the Developer Portal. There are three collaborator roles:
     </p>
@@ -77,8 +77,7 @@ Each role has a defined set of permissions for actions that can be taken by a te
 </details>
 
 ***
-## Giving Collaborators Access to Developer Sandbox Environments
-
+## Give Collaborators Sandbox Access
 As an App Owner, you can provide your collaborators with access to a development sandbox using the following steps:
 
 1. Log in to the sandbox company for your app and navigate to the **Company Directory** tool.

--- a/building_applications/building_apps_promote_manifest.md
+++ b/building_applications/building_apps_promote_manifest.md
@@ -12,7 +12,7 @@ After creating an app, you can modify its components using the Configuration Bui
 <br><br>
 
 ***
-## Versioning Your App
+## Versioning and Release Notes
 When you are ready to release a new app version, promote it to Production and include release notes that describe what has changed. These notes appear to Procore Company Admins during the update process and—if your app is listed on the Marketplace—also appear on your Marketplace listing.
 
 Use clear and accurate release notes to help users understand what is new or changed.
@@ -26,7 +26,7 @@ Procore apps follow <a href="https://semver.org/" target="_blank">Semantic Versi
 </details>
 
 ***
-## Promoting Your App & Notifying Users
+## Promote to Production
 After promoting a version to Production, Procore notifies customers when an update is available. Company Admins will see an **"Update Available"** badge in the App Management section of the Company Admin Tool.
 
 ### Promotion Steps

--- a/building_applications/building_data_connection_apps.md
+++ b/building_applications/building_data_connection_apps.md
@@ -82,7 +82,7 @@ Once you're satisfied with testing, promote your sandbox version to production. 
 <br><br>
 
 ***
-## Next steps
+## Next Steps
 - [API Usage Guidelines]({{ site.url }}{{ site.baseurl }}{% link platform_concepts/api_usage_guidelines.md %}) — rate limits, permitted usage, and when to use REST vs. Agentic APIs.
 - [Choosing an OAuth 2.0 Grant Type]({{ site.url }}{{ site.baseurl }}{% link oauth/oauth_choose_grant_type.md %}) — pick User Level vs. Service Account authentication.
 - [Developer Managed Service Accounts (DMSA)]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/developer_managed_service_accounts.md %}) — set up Service Account authentication.

--- a/building_applications/building_embedded_apps.md
+++ b/building_applications/building_embedded_apps.md
@@ -44,7 +44,7 @@ For the full list of supported view keys and URL patterns, see the [Side Panel V
 ***
 <details>
   <summary class="collapseListH2">
-    Accessing Procore Context
+    Access Procore Context
     <span class="collapseSubhead">Side panel apps can read the Procore context they're running in — company, project, resource, and view — using the MessageEvent interface and Window.postMessage(). Expand for the fields and setup code.</span>
   </summary>
   <div markdown="1">

--- a/building_applications/side_panel_view_keys.md
+++ b/building_applications/side_panel_view_keys.md
@@ -23,7 +23,7 @@ Use this reference when selecting **Supported Side Panel Views** in the Develope
 <br><br>
 
 ***
-#### Commitments
+## Commitments
 
 
 | URL Path | View Key |
@@ -77,7 +77,7 @@ Use this reference when selecting **Supported Side Panel Views** in the Develope
 | /:project_id/project/commitments/purchase_order_contracts/:purchase_order_contract_id<br />/change_orders/commitment_contract_change_orders/:id/edit | commitments.commitment_contract_change_orders.edit |
 
 
-#### Commitments Beta
+## Commitments Beta
 
 
 | /webclients/host/companies/:company_id/projects/:project_id/tools/contracts/commitments | commitments.contracts.list |
@@ -95,7 +95,7 @@ Use this reference when selecting **Supported Side Panel Views** in the Develope
 | /webclients/host/companies/:company_id/projects/:project_id/tools/contracts/commitments/work_order_contracts/:id<br />/ssov | commitments.work_order_contracts.detail |
 
 
-#### Contracts
+## Contracts
 
 
 | URL Path | View Key |
@@ -139,7 +139,7 @@ Use this reference when selecting **Supported Side Panel Views** in the Develope
 | /:project_id/project/contracts/prime_contracts/:prime_contract_id/invoices | prime_contracts.invoices.list |
 
 
-#### Prime Contracts
+## Prime Contracts
 
 
 | URL Path | View Key |
@@ -168,7 +168,7 @@ Use this reference when selecting **Supported Side Panel Views** in the Develope
 | /:project_id/project/prime_contracts/:prime_contract_id/payment_applications/:id/edit | prime_contracts.payment_applications.edit |
 
 
-#### Change Events
+## Change Events
 
 
 | URL Path | View Key |
@@ -179,7 +179,7 @@ Use this reference when selecting **Supported Side Panel Views** in the Develope
 | /:project_id/project/change_events/events/:id/edit | change_events.edit |
 
 
-#### Budget
+## Budget
 
 
 | URL Path | View Key |
@@ -191,7 +191,7 @@ Use this reference when selecting **Supported Side Panel Views** in the Develope
 | /:project_id/project/budgeting/change_history | budgeting.change_history.list |
 
 
-#### Submittal Logs
+## Submittal Logs
 
 
 | URL Path | View Key |
@@ -199,7 +199,7 @@ Use this reference when selecting **Supported Side Panel Views** in the Develope
 | /:project_id/project/submittal_logs/:id | submittal_logs.detail |
 
 
-#### Project Directory
+## Project Directory
 
 
 | URL Path | View Key |
@@ -208,7 +208,7 @@ Use this reference when selecting **Supported Side Panel Views** in the Develope
 | /:project_id/project/directory/edit_person/:id | project_directory.person.edit |
 
 
-#### Observations
+## Observations
 
 
 | URL Path | View Key |
@@ -217,7 +217,7 @@ Use this reference when selecting **Supported Side Panel Views** in the Develope
 | /:project_id/project/observations/items | observations.list |
 
 
-#### RFIs
+## RFIs
 
 
 | URL Path | View Key |
@@ -225,7 +225,7 @@ Use this reference when selecting **Supported Side Panel Views** in the Develope
 | /:project_id/project/rfi/show/:id | rfi.detail |
 
 
-#### Inspections
+## Inspections
 
 
 | URL Path | View Key |
@@ -233,7 +233,7 @@ Use this reference when selecting **Supported Side Panel Views** in the Develope
 | /:project_id/project/checklists/lists/:id | inspections.detail |
 
 
-#### Correspondence
+## Correspondence
 
 
 | URL Path | View Key |
@@ -241,7 +241,7 @@ Use this reference when selecting **Supported Side Panel Views** in the Develope
 | /:project_id/project/generic_tool/show/:id | correspondence.detail |
 
 
-#### Schedule
+## Schedule
 
 
 | URL Path | View Key |
@@ -253,7 +253,7 @@ Use this reference when selecting **Supported Side Panel Views** in the Develope
 | /:project_id/project/calendar/tasks/:task_id | schedule.calendar.task.detail |
 
 
-#### Incidents
+## Incidents
 
 
 | URL Path | View Key |

--- a/document_management_integration/document_management_intro.md
+++ b/document_management_integration/document_management_intro.md
@@ -6,8 +6,7 @@ section_title: "Integration Guides: Document Management"
 
 ---
 
-## Working with Document Management
-
+## Overview
 The Procore Document Management (PDM) system provides a platform for integrators to programmatically sync documents from external systems into Procore projects.
 Before you begin working with the various Document Management API endpoints, we recommend familiarizing yourself with the core concepts, architecture, and workflows outlined in this guide.
 

--- a/document_management_integration/document_management_metadata_details.md
+++ b/document_management_integration/document_management_metadata_details.md
@@ -5,6 +5,9 @@ layout: default
 section_title: "Integration Guides: Document Management"
 
 ---
+
+## Overview
+
 Document metadata is the foundation of how Procore Document Management (PDM) organizes, filters, and manages documents.  
 Document Metadata is a set of attributes that provide information about a document. Metadata can include file-level attributes (Type, Discipline, Number, Status) that describe what the document is, project/company attributes (Location, Trade, Area, etc.) that describe where and how the document applies, and other custom fields configured at the project level.
 
@@ -402,7 +405,7 @@ Use the following structuring rules and reference table to correctly construct y
 
 To identify which fields are configured for a specific project, query the [List Project Fields](https://developers.procore.com/reference/rest/project-fields?version=2.0#list-project-fields) endpoint.
 
-## Metadata Population Sources
+## How Metadata Gets Populated
 
 Metadata can be populated through several automated and manual mechanisms:
 
@@ -412,8 +415,7 @@ Metadata can be populated through several automated and manual mechanisms:
 
 Each field's `label_source` property in API responses indicates how the value was populated.
 
-## Understanding Field Value Sources
-
+## The `label_source` Property
 When metadata is populated in Document Management, each field includes a `label_source` property indicating how the value was populated:
 
 | Source | Description | User-Overrideable? |

--- a/document_management_integration/document_management_technical_guide.md
+++ b/document_management_integration/document_management_technical_guide.md
@@ -6,6 +6,8 @@ section_title: "Integration Guides: Document Management"
 
 ---
 
+## Overview
+
 This guide walks you through the complete API workflow for uploading documents, enriching them with metadata, and submitting them as document revisions using the Procore Document Management V2 API.
 
 ***

--- a/erp_integration/erp_intro.md
+++ b/erp_integration/erp_intro.md
@@ -6,8 +6,7 @@ section_title: ERP Integration
 
 ---
 
-## Working with ERP Objects
-
+## Work with ERP Objects
 ERP Objects provide system integrators the ability to support the synchronization of Procore financial objects into and out of Procore via a designated approval workflow.
 Inside Procore, the ERP Integrations Tool acts as a type of “staging area” wherein financial objects require specific accounting approval before being formally added to a Procore company (import), or sent out for creation in an external application (export).
 ERP Objects effectively represent the staged record of financial objects pending approval in this designated staging area.
@@ -70,8 +69,7 @@ When the object is successfully created in the External Application, System Inte
 
 See the [ERP Technical Guide]({{ site.url }}{{ site.baseurl }}{% link erp_integration/erp_technical_guide.md %}) for details on creating the Webhook, Trigger, and ERP Connection.
 
-## Definitions
-
+## Key Terms
 | Term                      | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Accounting Approver       | A Procore user with admin-granted permission to review staged financial records in the ERP Integrations Tool. On ERP Imports, Accounting Approvers are responsible for vetting information before adding the detail to Procore itself. On ERP Exports, Accounting Approvers are responsible for vetting the object prior to create a parallel record in the External Application.                                                                                                                                                                                                                        |

--- a/erp_integration/erp_staged_records.md
+++ b/erp_integration/erp_staged_records.md
@@ -11,8 +11,7 @@ section_title: ERP Integration
 For an ERP object to be imported into Procore, records must be staged in the ERP Integration tool where an accountant can review and approve records for import. 
 Integrators can use the publicly accessible [**Staged Records API**](https://developers.procore.com/reference/rest/v1/erp-staged-record).
 
-## Configuration
-
+## Staged Records Configuration
 Procore utilizes the ERP metadata to determine whether or not an ERP Integration uses Staged Records instead of the legacy endpoints (`erp_vendors`, `erp_jobs`, etc).
 Staged Records functionality is enabled/disabled at the entity type level. 
 To enable Staged Records for an entity, add the following field to the ERP metadata.:
@@ -77,8 +76,7 @@ There are a few details to keep in mind when staging records for import.
 3. For Commitment-Level item types, only Staged Records that belong to a **synced** Project and **synced** Commitment will be displayed.
 4. Depending on the ERP Integration, Prime Contracts can be re-imported. In this case, the Prime Contract can be re-imported if it is marked as `imported`.
 
-## Staging Project-Level Item Types
-
+## Stage Project-Level Item Types
 When creating Staged Records via the API for the item types below, it is **required** to include information about which Project the Staged Record belongs to.
 
 **Item Types:** `commitment_change_order, prime_contract, purchase_order_contract, sub_job, work_order_contract`
@@ -109,8 +107,7 @@ PATCH /staged_records/sync
   }
 ```
 
-## Staging Commitment-Level Item Types
-
+## Stage Commitment-Level Item Types
 In addition to being a Project-level item type, `commitment_change_order` must also belong to a `purchase_order_contract` or a `work_order_contract`.
 
 The payload **must** include `project_origin_id` **and** `commitment_origin_id` nested inside the `data` attribute. 
@@ -138,8 +135,7 @@ PATCH /staged_records/sync
   }
 ```
 
-## Staging Children Item Types
-
+## Stage Child Item Types
 Currently, the only supported child item type is `line_item`. 
 The `parent_id` attribute connects the children to a parent Staged Record.
 

--- a/erp_integration/erp_technical_guide.md
+++ b/erp_integration/erp_technical_guide.md
@@ -13,8 +13,7 @@ This guide will stick to the basics of an ERP integration. It is advised to refe
 
 ---
 
-## Getting Started
-
+## Get Started
 Before the Integration can start receiving Webhook events and processing events for a particular Procore company, a few things need to be setup:
 
 ### 1. Create a Developer Managed Service Account
@@ -64,8 +63,7 @@ Then you created a Trigger to indicate which resource you want to receive events
 
 ---
 
-## Receiving and Proccessing Events
-
+## Receive and Process Events
 At this point you may be asking, what causes an event to be fired off?
 
 There are a few main categories of events:

--- a/example apps and sdks/bim_webviewer/bim_web_viewer.md
+++ b/example apps and sdks/bim_webviewer/bim_web_viewer.md
@@ -7,9 +7,9 @@ section_title: Example Apps & SDKs
 
 <!-- markdownlint-disable no-inline-html -->
 
-## Getting started
+## Get Started
 
-<p class="heading-link-container"><a class="heading-link" href="#getting-started"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#get-started"></a></p>
 
 ### Installation from NPM (recommended)
 
@@ -4668,8 +4668,7 @@ GUI
 
 ---
 
-## Options
-
+## Viewer Options
 <p class="heading-link-container"><a class="heading-link" href="#options"></a></p>
 
 ### Required Options
@@ -5029,9 +5028,9 @@ Locale to use for display language, number formatting, and other localization.
 
 Defaults to `'en'`.
 
-## Objects
+## Viewer Objects
 
-<p class="heading-link-container"><a class="heading-link" href="#objects"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#viewer-objects"></a></p>
 
 ### Perspective Camera Object
 
@@ -5332,10 +5331,10 @@ export const derangify = (rangified: {
 }
 ```
 
-## Constants
+## Viewer Constants
 
 <p class="heading-link-container">
-  <a class="heading-link" href="#constants"></a>
+  <a class="heading-link" href="#viewer-constants"></a>
 </p>
 
 ### Uom

--- a/example apps and sdks/bim_webviewer/bim_web_viewer.md
+++ b/example apps and sdks/bim_webviewer/bim_web_viewer.md
@@ -73,7 +73,7 @@ const viewer = new ProcoreBim.Webviewer(options);
 viewer.start();
 ```
 
-See the [Options](#options) section for more detail on the options object.
+See the [Viewer Options](#viewer-options) section for more detail on the options object.
 
 ## Background Color
 
@@ -2613,7 +2613,7 @@ setOptions(options);
 #### Description
 
 Sets Webviewer configuration options.
-See [Options](#options).
+See [Viewer Options](#viewer-options).
 Currently can only set `selection`.
 
 #### Parameters
@@ -4604,7 +4604,7 @@ formatUnit(value, unit);
 
 Formats the value with the unit.
 
-- Uses locale passed in to [`Webviewer` options](#options) to display correct thousands and decimals separators for the locale.
+- Uses locale passed in to [`Webviewer` options](#viewer-options) to display correct thousands and decimals separators for the locale.
 - Rounds values to 4 decimal places and truncates trailing zeroes.
 
 ```ts
@@ -4669,7 +4669,7 @@ GUI
 ---
 
 ## Viewer Options
-<p class="heading-link-container"><a class="heading-link" href="#options"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#viewer-options"></a></p>
 
 ### Required Options
 

--- a/example apps and sdks/bim_webviewer/novolib_bim_web_viewer.md
+++ b/example apps and sdks/bim_webviewer/novolib_bim_web_viewer.md
@@ -7,9 +7,9 @@ section_title: Example Apps & SDKs
 
 <!-- markdownlint-disable no-inline-html -->
 
-## Getting started
+## Get Started
 
-<p class="heading-link-container"><a class="heading-link" href="#getting-started"></a></p>
+<p class="heading-link-container"><a class="heading-link" href="#get-started"></a></p>
 
 ### Installation from NPM (recommended)
 

--- a/example apps and sdks/procore_iframe_helper.md
+++ b/example apps and sdks/procore_iframe_helper.md
@@ -23,8 +23,7 @@ To install the package on your computer, run the following command in your proje
 
 If you need to install `npm` to your computer, visit the [NPM website](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) and follow the installation instructions they provide for your particular operating system.
 
-## Using the Library
-
+## Use the Library
 The Procore Iframe Helper library provides functions that help simplify your implementation of OAuth 2.0 within your embedded App. We recommend reviewing [Choosing an OAuth 2.0 Grant Type]({{ site.url }}{{ site.baseurl }}{% link oauth/oauth_choose_grant_type.md %}) and related Developer Portal articles before incorporating the library into your application. Here are the high-level steps for implementing authorization and authentication via OAuth 2.0 with the Procore Iframe Helper library:
 
 - On the landing page for your application, initialize the library using `const context = ProcoreIframeHelpers.initialize();`. This sets the proper context for subsequent calls to the library functions.

--- a/getting_started/rest_api_lifecycle.md
+++ b/getting_started/rest_api_lifecycle.md
@@ -6,7 +6,12 @@ layout: default
 section_title: Platform Concepts
 ---
 
-## API Lifecycle Phases
+## Overview
+
+Every Procore REST API resource moves through a defined lifecycle, from active support to eventual sunset.
+This page explains the three lifecycle phases, how Procore manages a resource through them, and what each phase means for an integration you have already built.
+
+## Lifecycle Phases
 
 The API lifecycle comprises three distinct phases.
 
@@ -14,7 +19,7 @@ The API lifecycle comprises three distinct phases.
 - **Deprecated**: Has been superseded by a newer API version. A deprecated API version will be supported for a period of one (1) year following the date of deprecation. However, no new development occurs during this phase. New applications are denied access to deprecated APIs.
 - **Sunset**: API resources are no longer available on production. This occurs at the conclusion of the ‘Deprecated’ phase.
 
-## API Lifecycle Management
+## Lifecycle Management
 
 This table provides additional information on how the Rest API product is managed through the lifecycle.
 
@@ -24,8 +29,7 @@ This table provides additional information on how the Rest API product is manage
 | Deprecated | API is live in Production                 | - Fixes deployed as needed<br>- No new development<br>- Technical support available at <apisupport@procore.com>                                        | - Endpoint reference pages marked as 'Deprecated'                        | - Developer Portal notification and announcement prior to deprecation<br> - Changelog entries published only for fixes and related changes  |
 | Sunset     | API is no longer accessible in Production | - Support no longer provided                                                                                                                           | - Reference pages no longer accessible in Production                     | - Developer Portal notification and announcement prior to sunset<br> - Final sunset announcement                                            |
 
-## Support
-
+## Need Help?
 Please reach out to <apisupport@procore.com> if you have any questions regarding the API lifecycle.
 
 ## See Also

--- a/getting_started/rest_api_overview.md
+++ b/getting_started/rest_api_overview.md
@@ -45,8 +45,7 @@ Breaking down this example further we see…
 - A new RFIs resource is added to REST API v2.0 starting with resource version 0.
 - REST v3.0 is released with all three example resources set to v3.0.
 
-## Making REST API Calls
-
+## Make REST API Calls
 The resource version is specified in the URL using the following format.
 
     /rest/v{api_version}.{resource_version}
@@ -135,7 +134,7 @@ Filters allow you to drill down on the types of changes you are most interested 
 
 ![changelog page]({{ site.baseurl }}/assets/guides/changelog-page.png)
 
-## Further Reading
+## See Also
 
 - [API Lifecycle and Deprecation]({{ site.url }}{{ site.baseurl }}{% link getting_started/rest_api_lifecycle.md %})
 - [API Request and Response Format]({{ site.url }}{{ site.baseurl }}{% link api_essentials/restful_api_concepts.md %})

--- a/oauth/oauth_auth_grant_flow.md
+++ b/oauth/oauth_auth_grant_flow.md
@@ -36,7 +36,7 @@ The high-level flow:
 6. Your app exchanges the authorization code for an access token via `/oauth/token`.
 7. Your app calls Procore APIs using the access token.
 
-## Step 1: Redirect the User to Procore's Authorization Endpoint
+## Step 1: Redirect the User
 
 > **Production vs. Sandbox.** Access tokens and refresh tokens are not shared between production and sandbox environments. Use the credentials and base URL for whichever environment you're targeting; the examples below use the production base URL (`https://login.procore.com`).
 {: .callout .callout--note}
@@ -59,7 +59,7 @@ Where:
 
 The user is presented with a Procore login screen. After successful login and approval, Procore redirects to your `<REDIRECT_URI>` with the authorization code in the query string. The authorization code is single-use and expires in 10 minutes.
 
-## Step 2: Exchange the Authorization Code for an Access Token
+## Step 2: Exchange the Code
 
 POST to `/oauth/token` with the authorization code:
 
@@ -95,8 +95,7 @@ curl -H "Authorization: Bearer <ACCESS_TOKEN>" \
      -X GET https://api.procore.com/rest/v1.0/me
 ```
 
-## Refreshing the Access Token
-
+## Refresh the Access Token
 The access token expires after 1.5 hours (5400 seconds). To renew it, POST to `/oauth/token` with the refresh token:
 
 ```
@@ -161,7 +160,7 @@ The initial authorization requires a one-time user interaction (logging in and p
 - Each refresh response returns a new access token AND a new refresh token. Save both.
 - As long as your app refreshes before the access token expires (1.5 hours), no further user interaction is needed.
 
-## Additional Resources
+## See Also
 
 - Most languages have OAuth 2.0 client libraries that wrap the request/exchange logic. See the [OAuth 2.0 client libraries directory](https://oauth.net/code/#client-libraries).
 - [Authentication Endpoints]({{ site.url }}{{ site.baseurl }}{% link oauth/oauth_endpoints.md %}) — full parameter reference for `/oauth/authorize`, `/oauth/token`, `/oauth/token/info`, and `/oauth/revoke`.

--- a/oauth/oauth_client_credentials.md
+++ b/oauth/oauth_client_credentials.md
@@ -22,8 +22,7 @@ There are a number of scenarios in which using the Client Credentials grant flow
 - Report generators - data mining, sync operations, or other integrations that access company-wide data.
 - Backend scripts - system maintenance and administration utilities.
 
-## Requesting an Access Token
-
+## Request an Access Token
 With a DMSA installed in Procore, request an access token by POSTing to the `/oauth/token` endpoint with `grant_type=client_credentials`. For full parameter details, see [Authentication Endpoints]({{ site.url }}{{ site.baseurl }}{% link oauth/oauth_endpoints.md %}).
 
 cURL example:
@@ -50,8 +49,7 @@ The JSON response block from the call includes an `access_token` string and addi
 - `expires_in` - value of 5400 indicates that the access token is valid for 5400 seconds (1.5 hours).
 - `created_at` - date/time the access token was generated in UNIX time format.
 
-## Making a Test Call to the Procore API
-
+## Make a Test Call
 Now that you have a valid access token you can make a test call to the Procore API. For this simple example, we will make a call to the [List Projects](https://developers.procore.com/reference/rest/v1/projects#list-projects) endpoint to return a list of the active projects in our company.
 
 ```
@@ -89,8 +87,7 @@ If successful, this call will return a JSON response block similar to the follow
 }
 ```
 
-## Using Developer Managed Service Accounts with MPR
-
+## Use DMSAs with MPR
 If you intend to use DMSAs with Multiple Procore Regions (MPR), you _must_ include the `Procore-Company-Id` request header when making calls to the `/rest/v1.0/me` or `/rest/v1.0/companies` endpoints.
 
 Here is a cURL example showing a call to `GET /rest/v1.0/me`:

--- a/oauth/oauth_endpoints.md
+++ b/oauth/oauth_endpoints.md
@@ -32,7 +32,7 @@ Three required request parameters are used with this endpoint as described in in
 
 Unlike the other endpoints, the Grant App Authorization endpoint requires user interaction. For step-by-step usage examples, see [OAuth 2.0 Authorization Code Grant Flow]({{ site.url }}{{ site.baseurl }}{% link oauth/oauth_auth_grant_flow.md %}).
 
-## Get Or Refresh an Access Token ([/oauth/token](https://developers.procore.com/reference/authentication#get-or-refresh-an-access-token))
+## Get or Refresh an Access Token ([/oauth/token](https://developers.procore.com/reference/authentication#get-or-refresh-an-access-token))
 
 The Get or Refresh an Access Token endpoint retrieves a new access token or refreshes an existing access token.
 Certain parameter combinations and values are used depending on which scenario you are handling.

--- a/oauth/oauth_keys.md
+++ b/oauth/oauth_keys.md
@@ -21,16 +21,14 @@ To ensure that the user's browser is directed back to the proper location, you a
 You can optionally manage two distinct sets of Redirect URIs for the sandbox and production environments, though this is not required.
 The `http://localhost` redirect URI is registered by default when you create a new application in the Developer Portal. Please note that dynamic URIs are not supported at this time.
 
-## Managing Sandbox OAuth Credentials and Redirect URIs
-
+## Manage Sandbox Credentials
 Using the OAuth Credentials section on the Manage App page you can view and manage the OAuth credentials and Redirect URIs for your sandbox.
 Your sandbox Client ID and Client Secret is accessible in this section and you can reset the Client Secret as needed.
 You can also add, update, or delete Redirect URIs for your sandbox.
 
 ![Sandbox Account screenshot]({{ site.baseurl }}/assets/guides/form-based-sandbox-oauth-creds.png)
 
-## Managing Production OAuth Credentials and Redirect URIs
-
+## Manage Production Credentials
 Using the OAuth Credentials section on the Manage App page you can view and manage the OAuth credentials and Redirect URIs for your production environment.
 Your production Client ID is accessible in this section and you can reset the Client Secret as needed.
 It is important to note that your production Client Secret is hidden from view in the OAuth Credentials section and only visible to you once when you initially obtain production credentials through the manifest promotion process.

--- a/overview/help_and_learning_center.md
+++ b/overview/help_and_learning_center.md
@@ -23,14 +23,14 @@ Here’s where to learn, find answers, and get help as you build on Procore. Use
 <br><br>
 
 ***
-## Procore certifications
+## Procore Certifications
 New to Procore? Start with our free, role‑based courses. You’ll learn product workflows in short, self‑paced modules that help you design better integrations and speak your users’ language.
 
 Take courses at <a href="https://learn.procore.com/" target="_blank">Procore Learning</a> (sign in with your Procore Developer account).
 <br><br>
 
 ***
-## Procore support site
+## Procore Support Site
 The Support Site is the primary source for customer‑facing product documentation. It includes:
 - Tutorials and step‑by‑step guides
 - FAQs
@@ -41,7 +41,7 @@ Explore the <a href="https://support.procore.com/products/online/user-guide" tar
 <br><br>
 
 ***
-## Developer support
+## Developer Support
 If you still have questions or run into an issue after checking the resources above, our Developer Support team can help with technical and non‑technical topics related to app development and API usage.
 
 **How to reach us**

--- a/overview/introduction.md
+++ b/overview/introduction.md
@@ -54,7 +54,8 @@ See the <a href="https://developers.procore.com/reference/rest/docs/rest-api-ove
 <br><br>
 
 ***
-## Start Here
+## Where to Begin
+{: .toc-exclude}
 - **Make your first API call:** [Quick Start Guide]({{ site.url }}{{ site.baseurl }}{% link overview/quick_start_guide.md %})
 - **Choose your app type:** [Available App Types]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/building_apps_app_types.md %})
 - **Set up authentication:** [Choosing an OAuth 2.0 Grant Type]({{ site.url }}{{ site.baseurl }}{% link oauth/oauth_choose_grant_type.md %})
@@ -62,6 +63,7 @@ See the <a href="https://developers.procore.com/reference/rest/docs/rest-api-ove
 - **Publish to the Marketplace:** [Technology Partner Overview]({{ site.url }}{{ site.baseurl }}{% link app_marketplace/procore_partner_overview.md %})
 
 ## Go Deeper
+{: .toc-exclude}
 - **Understand API usage:** [API Usage Guidelines]({{ site.url }}{{ site.baseurl }}{% link platform_concepts/api_usage_guidelines.md %})
 - **Plan for pagination:** [Using Pagination]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/pagination.md %})
 - **Receive change events:** [Introduction to Webhooks]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/webhooks.md %})

--- a/overview/quick_start_guide.md
+++ b/overview/quick_start_guide.md
@@ -18,7 +18,7 @@ Make your first Procore API call; this guide walks you through a single, linear 
 <br><br>
 
 <details>
-<summary class="collapseListTierOne">Step 1: Create Your App in the Developer Portal</summary>
+<summary class="collapseListH2">Step 1: Create Your App in the Developer Portal</summary>
 <p>
   <ol>
     <li>Sign in to the <a href="https://developers.procore.com/developers" target="_blank">Procore Developer Portal</a>.</li>
@@ -31,7 +31,7 @@ Make your first Procore API call; this guide walks you through a single, linear 
 
 ***
 <details>
-<summary class="collapseListTierOne">Step 2: Add a Data Connector Component</summary>
+<summary class="collapseListH2">Step 2: Add a Data Connector Component</summary>
 <p>
   A <b>Data Connector Component</b> enables your app to access Procore's REST APIs.
   <ol>
@@ -46,7 +46,7 @@ Make your first Procore API call; this guide walks you through a single, linear 
 
 ***
 <details>
-<summary class="collapseListTierOne">Step 3: Update Your App's Redirect URI (for testing)</summary>
+<summary class="collapseListH2">Step 3: Update Your App's Redirect URI (for testing)</summary>
 <p>
   For quick testing, set a temporary out‑of‑band Redirect URI.
   <ol>
@@ -61,7 +61,7 @@ Make your first Procore API call; this guide walks you through a single, linear 
 
 ***
 <details>
-<summary class="collapseListTierOne">Step 4: Install Your App in the Developer Sandbox</summary>
+<summary class="collapseListH2">Step 4: Install Your App in the Developer Sandbox</summary>
 <p>
   Each app includes a Developer Sandbox for testing. Only the App Creator is added by default. To add testers, see <a href="https://support.procore.com/products/online/user-guide/company-level/directory/tutorials/add-a-user-account-to-the-company-directory" target="_blank">Add a User Account to the Company Directory</a>.
   <ol>
@@ -76,7 +76,7 @@ Make your first Procore API call; this guide walks you through a single, linear 
 
 ***
 <details>
-<summary class="collapseListTierOne">Step 5: Generate an Authorization Code</summary>
+<summary class="collapseListH2">Step 5: Generate an Authorization Code</summary>
 <p>
   Replace <b>CLIENT_ID</b> with your Sandbox Client ID and open the URL in your browser to authorize.
   <ul>
@@ -88,7 +88,7 @@ Make your first Procore API call; this guide walks you through a single, linear 
 
 ***
 <details>
-<summary class="collapseListTierOne">Step 6: Exchange the Code for an Access Token</summary>
+<summary class="collapseListH2">Step 6: Exchange the Code for an Access Token</summary>
 <p>
   Use Postman (or any API client) to exchange the code for a token.
   <ol>
@@ -117,7 +117,7 @@ Make your first Procore API call; this guide walks you through a single, linear 
 
 ***
 <details>
-<summary class="collapseListTierOne">Step 7: Test API Requests</summary>
+<summary class="collapseListH2">Step 7: Test API Requests</summary>
 <p>
   With a valid access token, you can call Procore's REST APIs. Use the <b>Authorization</b> header with the Bearer token. API calls use the <code>https://sandbox.procore.com</code> base URL.
   <br><br>
@@ -150,7 +150,7 @@ Make your first Procore API call; this guide walks you through a single, linear 
 <div class="details-bottom-spacing"></div>
 
 ***
-## You just made your first Procore API call
+## Next Steps
 You've created an app, authenticated with OAuth 2.0, and retrieved real data from Procore. From here:
 
 - **Plan your integration:** [Available App Types]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/building_apps_app_types.md %})

--- a/overview/verification_and_production_access.md
+++ b/overview/verification_and_production_access.md
@@ -22,8 +22,7 @@ If you're a Procore customer building an integration for your own company's inte
 <div class="details-bottom-spacing"></div>
 
 ***
-## Unverified
-
+## Unverified Accounts
 All new Developer Portal accounts start as Unverified.
 
 As an Unverified developer, you can:
@@ -92,8 +91,7 @@ As a verified Marketplace Partner, you can:
 <br><br>
 
 ***
-## Getting to Production
-
+## Get to Production
 Reaching production requires clearing two gates, regardless of which verification path you take.
 
 ### Step 1: Verify your organization
@@ -115,8 +113,7 @@ This step happens for every app you want to promote to production. If you build 
 <br><br>
 
 ***
-## Comparison
-
+## Compare the Paths
 | | Unverified | Private Developer | Marketplace Partner |
 |---|:---:|:---:|:---:|
 | Create apps | ✓ | ✓ | ✓ |
@@ -129,7 +126,7 @@ This step happens for every app you want to promote to production. If you build 
 <div class="details-bottom-spacing"></div>
 
 ***
-## See also
+## See Also
 
 - [App Versioning & Production]({{ site.url }}{{ site.baseurl }}{% link building_applications/building_apps_promote_manifest.md %})
 - [Partner & Marketplace Overview]({{ site.url }}{{ site.baseurl }}{% link app_marketplace/procore_partner_overview.md %})

--- a/plan_your_app/building_apps_app_types.md
+++ b/plan_your_app/building_apps_app_types.md
@@ -13,9 +13,9 @@ Procore apps are built from two families of capabilities — **Data Connector** 
 Authentication is chosen separately and applies across families — see [Choosing an OAuth 2.0 Grant Type]({{ site.url }}{{ site.baseurl }}{% link oauth/oauth_choose_grant_type.md %}).
 <br><br>
 
-{% comment %} AGENTIC WIP (hidden until the agentic feature ships, ~Q3 2026). To restore: un-comment this section, re-add "Agentic" to the Overview above, and renumber the families back to 1/2/3.
+{% comment %} AGENTIC WIP (hidden until the agentic feature ships, ~Q3 2026). To restore: un-comment this section, re-add "Agentic" to the Overview above. Do NOT renumber — these are alternatives to choose between, not steps (see H2 Heading Standard).
 
-## 1. Agentic Apps
+## Agentic Apps
 
 **What it is**  
 Add AI-driven capabilities to your app, declared in the standard App Manifest and governed through Procore's install-and-consent flow. The agentic runtime is provided by **Datagrid, a Procore Company**.
@@ -28,7 +28,7 @@ See [Building Agentic Applications]({{ site.url }}{{ site.baseurl }}{% link buil
 {% endcomment %}
 
 ***
-## 1. Data Connector Apps
+## Data Connector Apps
 
 **What it is**  
 Move data between Procore and other systems (for example, accounting, ERP, document management, or equipment tracking).
@@ -49,7 +49,7 @@ See also: [Building Data Connector Apps]({{ site.url }}{{ site.baseurl }}{% link
 <br><br>
 
 ***
-## 2. Embedded Apps
+## Embedded Apps
 
 **What it is**  
 Run your app inside Procore’s web UI to keep users in context and reduce app switching.
@@ -67,8 +67,7 @@ A side panel app renders in a fixed 400‑px panel on the right side of the Proc
 See [Building Embedded Applications]({{ site.url }}{{ site.baseurl }}{% link building_applications/building_embedded_apps.md %}) to build either placement.
 <br><br>
 
-***
-## Example Images (Optional)
+### Optional: Example Images
 
 Use these examples to understand placement and layout.
 

--- a/plan_your_app/developer_managed_service_accounts.md
+++ b/plan_your_app/developer_managed_service_accounts.md
@@ -18,7 +18,7 @@ Once the App is installed, the company administrator can add or remove permitted
 
 Developers utilize DMSAs to provide a more convenient and secure alternative to traditional service accounts that must be created, configured, and managed manually by a company administrator.
 
-## Benefits of Using Developer Managed Service Accounts (DMSAs)
+## DMSA Benefits
 
 There are a number of benefits to be gained by using DMSAs over traditional service accounts:
 
@@ -35,7 +35,7 @@ With traditional service accounts, project access is configured and managed manu
 - **Better Insight on Application Usage** - Because DMSAs are installed using App Management, company administrators have visibility into application usage in the form of application metrics such as the number of API requests, which users have installed and/or used an application, which projects are permitted to use an application, and more
 With traditional service accounts, such metrics are neither gathered nor accessible.
 
-## Risks Associated with Traditional Service Accounts
+## Traditional Service Account Risks
 
 Installing and using applications that utilize traditional service accounts comes with the following risks:
 
@@ -46,7 +46,7 @@ The transmission of this sensitive information can unfortunately occur through u
 
 - **Potential for Human Error** - The requirement to manually configure and manage the permissions associated with a traditional service account can be error prone and lead to unexpected application behavior.
 
-## How does a DMSA differ from a traditional service account?
+## DMSA vs. Traditional Service Accounts
 
 Here are some of the primary differences between DMSAs and traditional service accounts.
 
@@ -138,7 +138,7 @@ The App will only have access to the data in these permitted projects.
 After the App is installed, company administrators can use the App Management feature in Procore to add/remove permitted projects as needed.
 See [What is App Management?](https://support.procore.com/faq/what-is-app-management), [Add a Permitted Project to a Data Connection App](https://support.procore.com/products/online/user-guide/company-level/admin/tutorials/add-permitted-project), and [Remove a Permitted Project from a Data Connection App](https://support.procore.com/products/online/user-guide/company-level/admin/tutorials/remove-permitted-project).
 
-## Best Practices for DMSA Permissions Management
+## Permissions Best Practices
 
 Managing permissions for a Developer Managed Service Account (DMSA) involves careful consideration to ensure application functionality and account security.
 Below are best practices and important considerations for managing permissions effectively.

--- a/plan_your_app/pagination.md
+++ b/plan_your_app/pagination.md
@@ -17,7 +17,7 @@ Most Procore REST endpoints support pagination to keep responses fast and predic
 <div class="details-bottom-spacing"></div>
 
 ***
-## per_page and page parameters
+## `per_page` and `page` Parameters
 
 Use two query parameters to paginate results:
 
@@ -36,7 +36,7 @@ See [Rate Limiting]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/rate_l
 <br><br>
 
 ***
-## Use Link headers to navigate
+## Use Link Headers to Navigate
 
 Procore includes pagination metadata in response headers:
 
@@ -63,7 +63,7 @@ From this response you can see that there are **150** total items, **5** items p
 <br><br>
 
 ***
-## Notes on the `page` parameter
+## Notes on the `page` Parameter
 
 - If `page=1`, the `Link` header includes `next` and `last`.
 - If `page=2`, the `Link` header includes `first`, `next`, and `last`.

--- a/plan_your_app/rate_limiting.md
+++ b/plan_your_app/rate_limiting.md
@@ -14,7 +14,7 @@ The headers returned may reflect either the spike limit or the hourly limit. The
 <br><br>
 
 ***
-## What counts against your limit
+## What Counts Against Your Limit
 
 Every request your app sends counts against your rate limit, including requests that fail. A `400`, `403`, or `404` response consumes quota exactly like a successful call.
 
@@ -106,7 +106,7 @@ Follow these practices to reduce the chance of hitting rate limits and to build 
 <br><br>
 
 ***
-## Request a higher limit
+## Request a Higher Limit
 
 If your app consistently approaches its limit after you have applied these practices, you can request an increase. Approval depends on your production traffic, your backoff behavior, and your error rate. See [Request a Rate Limit Increase]({{ site.url }}{{ site.baseurl }}{% link api_essentials/rate_limit_increase.md %}).
 <br><br>

--- a/plan_your_app/webhooks.md
+++ b/plan_your_app/webhooks.md
@@ -23,7 +23,7 @@ Think of a webhook as a **notification that something already happened in Procor
 <br><br>
 
 ***
-## How Webhooks Work
+## The Webhook Flow
 1. An event occurs in Procore (Web, Mobile, or API).
 2. If webhooks are configured at the company or project level, Procore sends an HTTPS `POST` to your endpoint with an **event object** in the JSON body.
 3. For creates and updates, your service can make a follow‑up `GET` to the Procore API to retrieve details for the changed resource.
@@ -184,7 +184,7 @@ The key distinction: a delayed or missing webhook is a **notification** problem,
 <br><br>
 
 ***
-## Next steps
+## Next Steps
 
 - **[Set Up Webhooks]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/webhooks_api.md %})** — create and manage hooks and triggers via the API.
 - Configure in the Procore UI: [Company Webhooks](https://support.procore.com/products/online/user-guide/company-level/admin/tutorials/configure-company-webhooks) · [Project Webhooks](https://support.procore.com/products/online/user-guide/project-level/admin/tutorials/configure-webhooks).

--- a/plan_your_app/webhooks_api.md
+++ b/plan_your_app/webhooks_api.md
@@ -31,7 +31,7 @@ This guide is a quick start with light best practices. It intentionally avoids U
 <br><br>
 
 ***
-## 1) Create a Hook
+## 1. Create a Hook
 
 > **Keep `destination_headers` minimal and do not log secrets.** Rotate tokens periodically.
 {: .callout .callout--warning}
@@ -75,7 +75,7 @@ Create a hook for the company **or** project you want to receive events from.
 <div class="details-bottom-spacing"></div>
 
 ***
-## 2) Add Triggers
+## 2. Add Triggers
 
 Triggers define which resource events should generate webhooks.
 
@@ -103,7 +103,7 @@ Triggers define which resource events should generate webhooks.
 <br><br>
 
 ***
-## 3) Monitor Deliveries
+## 3. Monitor Deliveries
 
 Use deliveries to see what Procore sent to your endpoint and how your endpoint responded.
 
@@ -153,8 +153,7 @@ In order to ensure that you do not receive multiple notifications, it is recomme
 <br><br>
 
 ***
-## Troubleshooting
-
+## Troubleshoot Webhooks
 - Nothing arriving? Confirm you created both a **hook** and at least one **trigger** in the **same scope** (company vs project) and API version.
 - Seeing loops? Filter out events initiated by your service account or app using event metadata.
 - Many failures? Inspect delivery `response_status` and `response_error`, confirm your endpoint returns `2xx` on success, and that secrets/URLs are correct.

--- a/platform_concepts/api_usage_guidelines.md
+++ b/platform_concepts/api_usage_guidelines.md
@@ -15,7 +15,7 @@ If your use case involves AI agents, semantic retrieval, or large-scale analytic
 <br><br>
 
 ***
-## Permitted use cases
+## Permitted Use Cases
 
 REST APIs are built for transactional workflows that complement your app's core integration:
 
@@ -26,7 +26,7 @@ REST APIs are built for transactional workflows that complement your app's core 
 <br><br>
 
 ***
-## What REST APIs are not designed for
+## What REST APIs Are Not Designed For
 
 Procore's transactional REST APIs are **not intended for**:
 
@@ -39,7 +39,7 @@ These activities can impact platform stability, degrade performance for customer
 <br><br>
 
 ***
-## Best practices
+## Best Practices
 
 To maintain platform performance and stay in compliance:
 
@@ -50,7 +50,7 @@ To maintain platform performance and stay in compliance:
 <br><br>
 
 ***
-## See also
+## See Also
 - <a href="https://developers.procore.com/reference/rest/docs/rest-api-overview" target="_blank">REST API Reference</a>
 - [Rate Limiting]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/rate_limiting.md %})
 - [Agentic APIs]({{ site.url }}{{ site.baseurl }}{% link announcements/agentic_apis.md %}) — for AI agents, semantic retrieval, and advanced analytics use cases

--- a/platform_concepts/building_apps_install_arch.md
+++ b/platform_concepts/building_apps_install_arch.md
@@ -19,7 +19,7 @@ This page explains the full app installation and setup flow for a Procore compan
 ***
 <details>
   <summary class="collapseListH2">
-    Step 1. App Installation
+    Step 1: Install the App
     <span class="collapseSubhead">All apps must be installed in the customer’s Procore company before they can run. Until installed, API requests that need company or project context return 4xx errors. If your app serves multiple customers, install it in <b>each</b> customer company you call.</span>
   </summary>
   <div markdown="1">
@@ -46,7 +46,7 @@ This page explains the full app installation and setup flow for a Procore compan
 ***
 <details>
   <summary class="collapseListH2">
-    Step 2. View Post‑Installation Notes
+    Step 2: View Post‑Installation Notes
     <span class="collapseSubhead">After install, Procore shows the developer‑provided post‑installation notes. Use these to tell installers what to do next in your product and in Procore.</span>
   </summary>
   <div markdown="1">
@@ -69,7 +69,7 @@ This page explains the full app installation and setup flow for a Procore compan
 ***
 <details>
   <summary class="collapseListH2">
-    Step 3. Finalize App Setup
+    Step 3: Finalize App Setup
     <span class="collapseSubhead">Installation enables access, but most apps still require setup. Follow the pattern for your app capabilities.</span>
   </summary>
   <div markdown="1">
@@ -108,16 +108,14 @@ This page explains the full app installation and setup flow for a Procore compan
 </details>
 
 ***
-## Related Articles
+## See Also
+
 - <a href="https://support.procore.com/faq/what-is-app-management" target="_blank">What is App Management?</a>
 - <a href="https://support.procore.com/faq/what-are-app-configurations" target="_blank">What are App Configurations and How Do I Work With Them?</a>
 - <a href="https://support.procore.com/products/online/user-guide/company-level/admin/tutorials/install-app-from-marketplace" target="_blank">Install an App from the Marketplace</a>
 - <a href="https://support.procore.com/products/online/user-guide/company-level/admin/tutorials/install-a-custom-app" target="_blank">Install a Custom App</a>
 - <a href="https://support.procore.com/products/online/user-guide/company-level/admin/tutorials/create-app-configuration" target="_blank">Create an App Configuration and Apply it to Projects</a>
 - <a href="https://support.procore.com/products/online/user-guide/project-level/home/tutorials/launch-embedded-app" target="_blank">Launch an Embedded App in a Project</a>
-
-## See Also
-
 - [Procore Environments]({{ site.url }}{{ site.baseurl }}{% link platform_concepts/development_environments.md %})
 - [Create an App]({{ site.url }}{{ site.baseurl }}{% link building_applications/building_apps_intro.md %})
 - [Available App Types]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/building_apps_app_types.md %})

--- a/platform_concepts/federal_zone_overview.md
+++ b/platform_concepts/federal_zone_overview.md
@@ -15,17 +15,13 @@ This page explains how the Federal Zone differs from Commercial, what changes fo
 
 ***
 
-## What’s Different at a Glance
+## Federal vs. Commercial Differences
 - Separate environment, infrastructure, and tenants from Commercial.
 - Separate **Developer Portal** and **Marketplace**; apps are not shared between environments.
 - Unique app registration and credentials per environment.
 - Different OAuth and API endpoints (see table below).
 - No sandbox environments in the Federal Zone.
 <br><br>
-
-***
-
-## Key Differences Between Federal and Commercial Environments
 
 > **Apps can't be shared between environments.** Each needs its own registration, credentials, and Marketplace listing.
 {: .callout .callout--note}
@@ -57,7 +53,7 @@ While not a full substitute for a sandbox, this approach provides the closest mo
 
 ***
 
-## How to Get Started as a Procore for Government Marketplace Partner
+## Get Started as a Government Partner
 
 > **The Federal Zone does not provide sandbox accounts.** All development and most testing should occur outside the Federal Zone before final validation.
 {: .callout .callout--note}

--- a/platform_concepts/object_model_overview.md
+++ b/platform_concepts/object_model_overview.md
@@ -17,7 +17,7 @@ The objects are grouped into three primary resource categories:
 
 Project-level resources are further broken down into the primary Procore Product Lines:
 
-- [Core]({{ site.url }}{{ site.baseurl }}{% link platform_concepts/object_model_project.md %}#core)
+- [Core Resources]({{ site.url }}{{ site.baseurl }}{% link platform_concepts/object_model_project.md %}#core-resources)
 - [Project Management]({{ site.url }}{{ site.baseurl }}{% link platform_concepts/object_model_project.md %}#project-management)
 - [Quality and Safety]({{ site.url }}{{ site.baseurl }}{% link platform_concepts/object_model_project.md %}#quality-and-safety)
 - [Construction Financials]({{ site.url }}{{ site.baseurl }}{% link platform_concepts/object_model_project.md %}#construction-financials)

--- a/platform_concepts/object_model_project.md
+++ b/platform_concepts/object_model_project.md
@@ -8,12 +8,12 @@ section_title: Platform Concepts
 
 The Project-level API resources are grouped into the following Procore Product Lines:
 
-- [Core](#core)
+- [Core Resources](#core-resources)
 - [Project Management](#project-management)
 - [Quality and Safety](#quality-and-safety)
 - [Construction Financials](#construction-financials)
 
-## Core
+## Core Resources
 
 ![Project-level Core Resources]({{ site.baseurl }}/assets/guides/resource-model-project-level-core.svg)
 

--- a/tutorials/attachments.md
+++ b/tutorials/attachments.md
@@ -220,7 +220,7 @@ Reference:
 Possible responses include `201`, `401`, `403`, and `422` depending on auth and validation.
 Some endpoints still support `image[data]` in `multipart/form-data`, but uploads-first with `upload.uuid` is the recommended flow for new integrations.
 
-## Next Step
+## Next Steps
 
 After you create or update the resource, use that tool's resource endpoint(s) to confirm the association in the returned payload.
 Use the endpoint-specific reference docs for the resource you are integrating.

--- a/tutorials/daily_logs.md
+++ b/tutorials/daily_logs.md
@@ -6,13 +6,14 @@ section_title: "Product Guides: Field Tools"
 
 ---
 
+## Overview
+
 Procore's Project level Daily Log tool is designed to provide project team members with a central location for viewing, tracking, and emailing updates about daily project activities.
 This guide provides some helpful hints for working with the Daily Log API endpoints.
 
 For additional information on Procore's Daily Log feature, see the [Daily Log](https://support.procore.com/products/online/user-guide/project-level/daily-log) articles on the [Procore Support](https://support.procore.com) site.
 
-## Filtering Logs by Date and Date Ranges
-
+## Filter Logs by Date
 Daily log information retrieved by List action endpoints can be filtered by date (or date ranges) using the following guidelines.
 
 - **Filtering by a Specific Date** - If you want to find logs for a specific date you must use the log_date query parameter with a date format of `YYYY-MM-DD`.  For example, `?log_date=2016-08-09`.
@@ -20,8 +21,7 @@ Daily log information retrieved by List action endpoints can be filtered by date
 
 **Note**: If none of the date parameters are provided in the call, only logs from the current (today's) date are returned.
 
-## Working with Locations in Daily Logs
-
+## Work with Locations
 A number of daily log endpoints support both single locations as well as multi-tier locations.
 For information on multi-tier locations in Procore, see this helpful [Support FAQ](https://support.procore.com/faq/how-do-i-add-a-multi-tiered-location-to-an-item).
 Here we use `quantity_log` as an example, but you can replace it with the name of the log you want to work with.
@@ -106,8 +106,7 @@ Currently, locations are supported in the Manpower log, Equipment log, Quantity 
 }
 ```
 
-## Working With Attachments
-
+## Work with Attachments
 Some logs have attachment capabilities through the API with the following limitations.
 
 - The following Daily Logs do **not** support attachments on the web:

--- a/tutorials/filtering_on_list_actions.md
+++ b/tutorials/filtering_on_list_actions.md
@@ -39,8 +39,7 @@ Some filters return an array of attribute values and can be used with the follow
 
 ```
 
-## Examples
-
+## Filter Examples
 Here are a few examples to get you started using the filtering capabilities in Procore API.
 
 First, let's look at a simple case of filtering a list of Work Order Contracts (subcontract) on the Status field.
@@ -74,8 +73,7 @@ GET https://sandbox.procore.com/rest/v1.0/purchase_order_contracts/
 It is important to note that the date-time string used with the `created_at` and `updated_at` parameters must adhere to ISO8601 standards.
 In addition, these parameters must be formatted as a range using the `...` delimiter.
 
-## Filtering on Deleted Objects
-
+## Filter on Deleted Objects
 You can return a list of only the deleted objects for a resource using the `filters[include_deleted]` query parameter.
 Here is an example for returning a list of deleted work order contracts.
 
@@ -86,8 +84,7 @@ GET https://api.procore.com/rest/v1.0/work_order_contracts/?project_id=123456&fi
 Notice that we use only as the value for the `filters[include_deleted]` parameter.
 This returns just the deleted items. Using a value of `with` returns deleted and undeleted items.
 
-## Filtering on User-Defined Field Values
-
+## Filter on User-Defined Field Values
 There are a number of resources in the Procore API (such as RFIs) that provide List Action filtering on fields that have user-defined values.
 For example, the List RFIs endpoint allows you to filter the response by responsible contractor ID using `filters[responsible_contractor_id]` as a query parameter.
 However, you must first use a helper method that returns the available values for the `responsible_contractor_id` field as illustrated below.
@@ -153,8 +150,7 @@ Note that calling the List Action with no date query parameters only returns rec
 
 See [Working with Daily Logs]({{ site.url }}{{ site.baseurl }}{% link tutorials/daily_logs.md %}) for additional information.
 
-## Sorting on List Actions
-
+## Sort on List Actions
 In addition to filtering the results of List Actions, you can also sort the results based on specified fields.
 Add sorting to your API call by adding the `sort` query parameter with the following syntax:
 

--- a/tutorials/tutorial_budget_changes_api.md
+++ b/tutorials/tutorial_budget_changes_api.md
@@ -15,12 +15,10 @@ Once Budget Changes are enabled for a Company, Budget Modifications are no longe
 
 As this feature is meant to extend the functionality of Budget Modifications, it is useful to know how Budget Changes relate to Budget Modifications. All of the original features available for Budget Modifications are available for Budget Changes. However the APIs do not behave similarly. This document is intended to provide a detailed explanation of how the Budget Modifications API, its request params and responses, correlate to the Budget Changes API.
 
-## Audience
-
+## Who This Guide Is For
 Any developer who has an application leveraging the [Budget Modifications Rest API](https://developers.procore.com/reference/rest/v1/budget-modifications?version=1.0) can use this document as a guide in building an application that uses the Budget Changes API to perform similar actions in the domain of Budget Changes.
 
-## Endpoints
-
+## Endpoint Reference
 ### Quick Reference
 * [List Endpoints](#list-apis)
 * [Show Endpoints](#show-apis)

--- a/tutorials/tutorial_budget_line_items.md
+++ b/tutorials/tutorial_budget_line_items.md
@@ -17,7 +17,7 @@ In preparation for working with budget views and budget line items using the Pro
 
 In addition, we recommend completing the [Construction Financials](https://learn.procore.com/series/procore-certification/procore-certification-project-manager-construction-financials) video training course available at [learn.procore.com](https://learn.procore.com/)
 
-## Understanding Budget Views
+## Budget Views
 Before working with budget line items using the Procore API, it is important to gain an understanding of _budget views_ and their associated workflows.
 Budgets created using the Procore Budget tool can have one or more views.
 Views provide visibility and insight into specific aspects of a budget, such as a buyout savings, change order analysis, commitment billing, and so on.
@@ -26,8 +26,7 @@ Prior to working with budget views we recommend visiting the following articles 
 - [Which budget views should I add to my projects?](https://support.procore.com/faq/which-budget-views-should-i-add-to-my-projects)
 - [Set up a New Budget View](https://support.procore.com/products/online/user-guide/company-level/admin/tutorials/set-up-a-new-budget-view)
 
-## Accessing Budget Views and Line Items Using the API
-
+## Access Budget Views and Line Items
 The Procore API provides the following endpoints for working with budget views and budget line items.
 
 | Endpoint                                                                                                                                 | Description                                                                                                                                                                                                                                                                                                                                                   |

--- a/tutorials/tutorial_change_orders.md
+++ b/tutorials/tutorial_change_orders.md
@@ -12,8 +12,7 @@ This tutorial provides insight and guidance for developers using the Change Orde
 Procore's Project level Change Orders tool streamlines the change management process by providing a centralized location for monitoring change orders that affect prime contracts and commitments.
 In construction management, _change orders_ represent the specific details of new work item added to the original scope of a construction project.
 
-## Understanding Change Order Tiers
-
+## Change Order Tiers
 In order to work effectively with the Change Orders API, you'll need a solid understanding of how Change Order Tiers work in Procore.
 Before, exploring the various Change Order API resources and endpoints, we recommend reading [What are the different change order tiers?](https://support.procore.com/faq/what-are-the-different-change-order-tiers) on the Procore Support site.
 

--- a/tutorials/tutorial_config_fieldsets.md
+++ b/tutorials/tutorial_config_fieldsets.md
@@ -16,8 +16,7 @@ When a project user interacts with a tool that supports configurable fieldsets, 
 
 The following tools do not yet support configurable fieldsets: Coordination Issues, Meetings, Schedule, Action Plans, Forms, Budget, Change Orders, and Direct Costs.
 
-## Understanding Configurable Validations
-
+## Configurable Validations
 > **Include null-valued required fields on update, or validation fails.** When updating a resource, a required field that already has a value only needs to be sent if you intend to change it — but if its existing value is null, you must include it in the request.
 {: .callout .callout--warning}
 
@@ -35,8 +34,7 @@ The absence of required fields in the request body returns an error indicating w
 
 ![project error]({{ site.baseurl }}/assets/guides/project-error.png)
 
-## Working with Custom Fields
-
+## Work with Custom Fields
 _Custom fields_ can be created for certain tools in Procore to allow for additional information to be filled out when creating or editing items.
 Custom fields can be created within fieldsets, or created separately and later applied to fieldsets.
 The following Procore Support Site articles provide general information on custom fields and how they are managed using the Procore web application.

--- a/tutorials/tutorial_correspondence.md
+++ b/tutorials/tutorial_correspondence.md
@@ -84,8 +84,7 @@ The endpoint names are linked to their corresponding reference pages.
 | [List Correspondence Type Defaults](https://developers.procore.com/reference/rest/v1/correspondences?version=1.0#list-correspondence-type-defaults)                   | GET    | /correspondence_types/defaults                                                                              | Returns a list of all Correspondence Types Defaults for the specified Project.                           |
 | [List Correspondence Type Users](https://developers.procore.com/reference/rest/v1/correspondences?version=1.0#list-correspondence-type-users)                         | GET    | /correspondence_types/users                                                                                 | Returns a list of all Correspondence Types Users Availability for the specified Project.                 |
 
-## Understanding Correspondence Tool Permissions
-
+## Correspondence Tool Permissions
 One key aspect of working with the Correspondence Tool API centers around the concept of permissions.
 Certain access levels (Read Only, Standard, and Admin) are required to perform certain tasks within the Correspondence Tool.
 Refer to the [Correspondence Tool Permissions](https://support.procore.com/products/online/user-guide/project-level/correspondence/permissions) article on the Procore Support Site for detailed information on the tasks allowed under each access level.
@@ -455,17 +454,12 @@ The request body defines updated field values for one or more items.
 
 ![Bulk Update Correspondence Items]({{ site.baseurl }}/assets/guides/batch-update-corres-items.png)
 
-## Webhooks
-
+## Correspondence Webhooks
 The Correspondence tool supports webhooks as described in [Introduction to Webhooks]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/webhooks.md %}) and [Using the Webhooks API]({{ site.url }}{{ site.baseurl }}{% link plan_your_app/webhooks_api.md %}). Procore customers can configure Correspondence webhooks using the Project Admin tool as outlined in [Configure Project Webhooks](https://support.procore.com/products/online/user-guide/project-level/admin/tutorials/configure-webhooks).
-
-## Further Reading
-
-- [Procore Support Articles - Correspondence Tool](https://support.procore.com/products/online/user-guide/project-level/correspondence)
-- [Working with Configurable Fieldsets]({{ site.url }}{{ site.baseurl }}{% link tutorials/tutorial_config_fieldsets.md %})
 
 ## See Also
 
+- [Procore Support Articles - Correspondence Tool](https://support.procore.com/products/online/user-guide/project-level/correspondence)
 - [Working with Configurable Fieldsets]({{ site.url }}{{ site.baseurl }}{% link tutorials/tutorial_config_fieldsets.md %})
 - [Working with User Permissions and Permission Templates]({{ site.url }}{{ site.baseurl }}{% link tutorials/tutorial_user_permissions.md %})
 - [Work Breakdown Structure]({{ site.url }}{{ site.baseurl }}{% link tutorials/tutorial_wbs.md %})

--- a/tutorials/tutorial_direct_drawing_uploads.md
+++ b/tutorials/tutorial_direct_drawing_uploads.md
@@ -91,14 +91,10 @@ When we log in to Procore, navigate to the Drawings tool in our project and sele
 
 ![ready-for-review]({{ site.baseurl }}/assets/guides/ready-for-review.png)
 
-## Further Reading
-
-Refer to Working with [Direct File Uploads]({{ site.url }}{{ site.baseurl }}{% link tutorials/tutorial_uploads.md %}) for general information on creating file uploads using the Procore API.
-
 ## See Also
 
 - [Working with the Documents Tool]({{ site.url }}{{ site.baseurl }}{% link tutorials/tutorial_documents.md %})
 - [Working with File Attachments and Image Uploads]({{ site.url }}{{ site.baseurl }}{% link tutorials/attachments.md %})
-- [Working with Direct File Uploads]({{ site.url }}{{ site.baseurl }}{% link tutorials/tutorial_uploads.md %})
+- [Working with Direct File Uploads]({{ site.url }}{{ site.baseurl }}{% link tutorials/tutorial_uploads.md %}) — general information on creating file uploads using the Procore API
 - [Working with Secure File Access]({{ site.url }}{{ site.baseurl }}{% link best_practices/secure_file_access_tips.md %})
 - [Working with Drawings]({{ site.url }}{{ site.baseurl }}{% link tutorials/tutorial_drawings.md %})

--- a/tutorials/tutorial_drawings.md
+++ b/tutorials/tutorial_drawings.md
@@ -21,8 +21,7 @@ Before you begin working with the various Drawings tool endpoints we recommend f
     - [Mark Up Drawings](https://www.youtube.com/watch?v=CzicT-q_O7k)
     - [Upload Drawing Revisions](https://www.youtube.com/watch?v=0DLPzeFT0v0)
 
-## Getting Started
-
+## Get Started
 ### Drawing Resources
 
 Before working with the Drawings Tool endpoints we recommend familiarizing yourself with the various Drawings Tool resources and how they relate to one another.
@@ -92,9 +91,7 @@ You can use the Permissions Table to manage/change user permissions for the Draw
 | [List Drawing Revisions](https://developers.procore.com/reference/rest/v1/drawings#list-drawing-revisions) | GET /rest/v1.0/projects/{project_id}/drawing_revisions                                     | Returns a list of all Drawing Revisions in the specified Project.                                                       |
 | [List Drawing Tiles](https://developers.procore.com/reference/rest/v1/drawings#list-drawing-tiles)         | GET /rest/v1.0/projects/{project_id}/drawing_revisions/{drawing_revision_id}/drawing_tiles | Lists the Drawing Tiles in the specified Project and Drawing Revision, along with the maximum Zoom Level and Tile Size. |
 
-## Using the API to Populate the Drawings Tool with Assets
-
-
+## Populate the Drawings Tool
 The following sections describe in general terms the tasks for setting up and populating the Drawing Tool with drawing assets.
 
 ### Creating a New Drawing Upload

--- a/tutorials/tutorial_field_prod.md
+++ b/tutorials/tutorial_field_prod.md
@@ -35,8 +35,7 @@ The Procore API provides the following endpoints for working with Timecard Entri
 | [Update Timecard Entry](https://developers.procore.com/reference/rest/v1/timecard-entries#update-timecard-entry) | Updates the information for a given Timecard Entry in the specified Project.     |
 | [Delete Timecard Entry](https://developers.procore.com/reference/rest/v1/timecard-entries#delete-timecard-entry) | Deletes a given Timecard Entry in the specified Project.                         |
 
-## Timesheets
-
+## Timesheet Configuration
 > **Match your parameters to the timesheet's time-entry setting.** A timesheet is configured at the project level for either Total Hours or Start Time and Stop Time, and creating entries via the API requires parameters consistent with that setting.
 {: .callout .callout--note}
 

--- a/tutorials/tutorial_financial_tools.md
+++ b/tutorials/tutorial_financial_tools.md
@@ -65,7 +65,7 @@ For technical questions or issues, please email our API Support team: <apisuppor
 In addition to just the technical [API Reference](https://developers.procore.com/reference) documentation, there are a few extended features that Procore provides to create a deeper, more robust integration between Procore and your ERP system.
 These features are covered in the following sections.
 
-## External IDs and Data - origin_id, origin_data, and origin_code
+## External IDs and Origin Data
 
 The `origin_id`, `origin_data`, and `origin_code` fields provide areas to store external data on a Procore object.
 These fields apply to the Projects, Vendors, Commitments, Change Orders, Direct Costs, Cost Codes, Users, Change Events, and Prime Contract resources.

--- a/tutorials/tutorial_mpz.md
+++ b/tutorials/tutorial_mpz.md
@@ -54,9 +54,7 @@ _Note_: The following Procore API endpoints _do not_ require a request header co
 The exception to this rule is when you are using Service Accounts with the OAuth 2.0 Client Credentials grant type.
 See [Using Service Accounts with MPR]({{ site.url }}{{ site.baseurl }}{% link oauth/oauth_client_credentials.md %}#using-service-accounts-with-mpz) for additional information.
 
-## Requirements
-
-All applications accessing the Procore API must be MPR-compliant. The `Procore-Company-Id` request header is required on all API calls (with the exception of the endpoints listed above). Applications that do not include this header will not be able to access data for Procore customers.
+Applications that do not include the `Procore-Company-Id` header will not be able to access data for Procore customers.
 
 ## Resource ID Value Size
 
@@ -71,6 +69,6 @@ _Answer_: Yes.
 Sandbox environments also require MPR-compliant API calls, including the `Procore-Company-Id` request header.
 For sandbox environment URLs and setup details, see [Sandbox Environments]({{ site.url }}{{ site.baseurl }}{% link platform_concepts/development_environments.md %}).
 
-## Need Additional Information?
+## Need Help?
 
 If you have any questions or need help in determining the impacts of MPR on your application codebase, please contact our [Technical Services](mailto:apisupport@procore.com) team for assistance.

--- a/tutorials/tutorial_observations.md
+++ b/tutorials/tutorial_observations.md
@@ -157,8 +157,7 @@ Once the work has been reviewed for completeness, the final step in the observat
 
 - Update the observation (PATCH /rest/v1.0/observations/items/{id}) including the `id` of the observation as a path parameter and setting the Status field in the request body to ‘closed’.
 
-## Adding Attachments to Observation Items
-
+## Add Attachments to Observation Items
 You can add an attachment to an observation item following the process outlined in [Working with File Attachments and Image Uploads]({{ site.url }}{{ site.baseurl }}{% link tutorials/attachments.md %}).
 Here is a Postman example showing a POST call to the [Create Observation Item](https://developers.procore.com/reference/rest/v1/observations#create-observation-item) endpoint with an included attachment.
 

--- a/tutorials/tutorial_project_stages.md
+++ b/tutorials/tutorial_project_stages.md
@@ -35,8 +35,7 @@ The Procore API provides the following endpoints for working with project stages
 | [Update Project Stage](https://developers.procore.com/reference/rest/v1/project-stages#update-project-stage) | Update a specified project stage.                                         |
 | [Delete Project Stage](https://developers.procore.com/reference/rest/v1/project-stages#delete-project-stage) | Delete a specified project stage.                                         |
 
-## Creating Custom Project Stages
-
+## Create Custom Project Stages
 You can use the Create Project Stage endpoint to create a new custom project stage.
 Each custom project stage you create is associated with one of the default project stages in your company account.
 The enumerated value you assign to the `category_type` attribute determines which default project stage the new custom project stage is mapped to.

--- a/tutorials/tutorial_timecard_entries.md
+++ b/tutorials/tutorial_timecard_entries.md
@@ -71,8 +71,7 @@ In the request body for the [Create Timecard Entry](https://developers.procore.c
 
 ![create-timecard-entry]({{ site.baseurl }}/assets/guides/create-timecard-entry.png)
 
-## Including Timecard Entry Hours in Project Budget Views
-
+## Include Timecard Hours in Budget Views
 After timecard entries are added to a project, labor hours can be accessed and included in project budget views using the Timecard Entry Hours source column.
 In order to make Timecard Entry Hours available as a source column, we first need to create a Timesheet to Budget Configuration.
 We include the `line_item_type_id` in the request body.

--- a/tutorials/tutorial_unified_uploads.md
+++ b/tutorials/tutorial_unified_uploads.md
@@ -36,8 +36,7 @@ It is also built with multi-cloud support in mind, so as Procore expands to addi
 > **Treat URLs and headers as opaque.** The presigned `url` and `headers` returned in each segment must be copied in their entirety and used exactly as provided in your PUT request. Do not parse, pattern-match, or make any assumptions about the URL structure or the set of headers — both are subject to change across API versions and environments without prior notice.
 {: .callout .callout--warning}
 
-## Endpoints
-
+## Endpoint Reference
 The Unified File Upload API is available at both the project level and the company level.
 Use project-level endpoints when uploading files that will be associated with a specific project resource (such as a PDM document).
 Use company-level endpoints when uploading files that will be associated with a company-level resource.
@@ -448,8 +447,7 @@ Use the `upload_id` from this upload (`01JEXAMPLE00000000000000002`) as the `fil
 
 ---
 
-## Checking Upload Status (GET)
-
+## Check Upload Status
 Use the Get Upload Status endpoint to check the current state of an upload, or to poll until the file is fully processed and available.
 
 **Request**
@@ -659,8 +657,7 @@ curl -X GET 'https://sandbox.procore.com/rest/v2.1/companies/{company_id}/upload
 
 Once `status` is `available`, the file can be associated with a company-level resource using the `upload_id`.
 
-## Coming Soon
-
+## Planned Capabilities
 The following capabilities are planned for upcoming releases of the Unified File Upload API:
 - **Malware scan** — Automated scanning of all uploaded files for malware
 - **Checksum verification status** — Fields confirming whether server-side checksum verification passed

--- a/tutorials/tutorial_uploads.md
+++ b/tutorials/tutorial_uploads.md
@@ -16,7 +16,7 @@ File uploads can be either segmented or non-segmented.
 The JSON block returned by these endpoints contains attributes that form the 'instructions' for uploading and storing files.
 Subsequent steps use these attributes to form a POST request to the file storage service.
 Once a file has been uploaded to a storage service you can use the Procore API to move the file into Procore and associate it with a resource.
-See [Moving an Uploaded File into Procore](#moving-an-uploaded-file-into-procore) for additional information.
+See [Move an Uploaded File into Procore](#move-an-uploaded-file-into-procore) for additional information.
 
 ## Upload Endpoints
 
@@ -308,7 +308,7 @@ Keep the following in mind when performing a direct file upload:
 - The URL and fields necessary to complete a direct file upload may vary between companies and may also change over time, so none of these may be hard-coded.
 - Uploads must be associated with a Procore resource within one week or they will be automatically deleted from Procore servers.
 
-## Moving an Uploaded File into Procore
+## Move an Uploaded File into Procore
 
 Once a file has been successfully uploaded to a storage service, we can move the file into Procore and associate it with a resource.
 This example shows using the [Create Project File](https://developers.procore.com/reference/rest/v1/project-folders-and-files#create-project-file) endpoint to move the file into Procore as a project document file.
@@ -323,7 +323,7 @@ The following endpoints may also be used to move uploaded files into Procore dep
 - [Create Project File](https://developers.procore.com/reference/rest/project-folders-and-files?version=latest#create-project-file)
 
 
-## Using upload id in API Requests
+## Use the Upload ID in API Requests
 
 This section provides examples of how to use the upload id when integrating with various Procore endpoints.
 
@@ -486,7 +486,7 @@ Creating a Meeting Topic with an attachment:
 }
 ```
 
-## Migrating from Legacy Uploads
+## Migrate from Legacy Uploads
 If you're currently using the legacy upload approach (via `attachments` or `data` attributes), we strongly recommend migrating to the `upload_id` approach. The benefits include:
 
 - Improved upload performance and reliability

--- a/tutorials/tutorial_user_permissions.md
+++ b/tutorials/tutorial_user_permissions.md
@@ -26,14 +26,14 @@ In order to update a project user’s permission template through the API, the u
 > **Before you begin.** To successfully complete this tutorial, you must have `Admin` permissions on the company-level Directory tool.
 {: .callout .callout--prereq}
 
-## Step 1 - Find the user whose permission template will be changed
+## Step 1: Find the User
 
 Using either the [List Project Users](https://developers.procore.com/reference/rest/v1/project-users#list-project-users) or [Show Project User](https://developers.procore.com/reference/rest/v1/project-users#show-project-user) endpoint, find the object associated with the user whose permission template you would like to change.
 The important values to note are the user’s `ID` and the `permission_template` object (if applicable).
 
 ![User Permissions - 01]({{ site.baseurl }}/assets/guides/user-permissions-01.png)
 
-## Step 2 - Removing the User from a Project
+## Step 2: Remove the User from a Project
 
 In order to change a user's permission template on a project, it is necessary to remove them and then re-add them to the same project.
 Performing this action will not delete or reassign any content from this user.
@@ -45,7 +45,7 @@ With the `ID` of the user you wish to change a project template for, use the [Re
 The successful removal of the user from this project will be indicated by a `204 No Content` HTTP status code (with an empty response body).
 This endpoint will remove a user from the given project, but not remove them from the company level directory.
 
-## Step 3 - Re-add the User to the Project
+## Step 3: Re-add the User to the Project
 
 Using the [Add Company User to Project](https://developers.procore.com/reference/rest/v1/project-users#add-company-user-to-project) endpoint, you can re-add the user to the project with the new `permission_template_id`.
 A successful request will be indicated by a `201 Created` HTTP response code.

--- a/tutorials/tutorial_wbs.md
+++ b/tutorials/tutorial_wbs.md
@@ -25,8 +25,7 @@ Before working with the WBS endpoints, we suggest a thorough review of the follo
 * [(WBS) Company Administration Guide](https://support.procore.com/products/online/work-breakdown-structure/company-administration-guide)
 * [(WBS) Project Administration Guide](https://support.procore.com/products/online/work-breakdown-structure/project-administration-guide)
 
-## Limitations
-
+## WBS Limitations
 * Creation of custom WBS segments is **not** currently supported in companies with Field Productivity and/or ERP Integrations tools enabled.
 
 ## WBS Resources
@@ -85,8 +84,7 @@ See [API Lifecycle](https://developers.procore.com/documentation/rest-api-lifecy
 If your existing integration uses any of these deprecated endpoints, or Cost Code, Cost Type and Sub Job endpoints in general, we encourage you to adopt the new [Work Breakdown Structure endpoints](https://developers.procore.com/reference/rest/v1/codes?version=1.0) and update your integration as needed.
 If you have any concerns please reach out to [apisupport@procore.com](mailto:apisupport@procore.com).
 
-## Understanding WBS Budget Code Patterns and Segments
-
+## WBS Budget Code Patterns and Segments
 ### Default Company WBS Pattern
 
 Each company includes a default WBS pattern representing a company budget code structure with the following legacy segments.

--- a/tutorials/tutorial_workflows.md
+++ b/tutorials/tutorial_workflows.md
@@ -50,8 +50,7 @@ Next, the Reviewer role can execute the `Approve` activity to transition the Pur
 Or, the Reviewer role can execute the `Deny` activity to send the Purchase Order back to the `Start` state for re-work by the Project Manager.
 We will refer to this example workflow as we work through the following sections.
 
-## Retrieving Workflow Information
-
+## Retrieve Workflow Information
 Each object (such as a Subcontract or Purchase Order) that has an associated workflow will have one (and only one) _workflow instance_.
 The workflow instance includes the name of the applied workflow, the current workflow state, and the activities that can be performed from the current workflow state.
 You can retrieve a list of active workflow instances for your company using the [List Workflow Instances](https://developers.procore.com/reference/rest/v1/workflow#list-workflow-instances) endpoint.
@@ -116,8 +115,7 @@ The example response provides details on a single workflow instance - `"id": 568
 However, under most conditions this call would return multiple instances as there would likely be more than one Purchase Order with a workflow applied.
 Examining this response we can determine the `current_workflow_state` (Start), the available `current_workflow_activities` (Submit for Approval), and other useful information about the workflow instance associated with our sample Purchase Order.
 
-## Performing Workflow Activities
-
+## Perform Workflow Activities
 In addition to retrieving information on existing workflow instances in your company, you can use the Workflow API to execute workflow actions (activities) to transition from one workflow state to the next.
 Once you have located the specific workflow instance you want to work with using the [List Workflow Instances](https://developers.procore.com/reference/rest/v1/workflow#list-workflow-instances) endpoint, you can use the [Create Workflow Activity History](https://developers.procore.com/reference/rest/v1/workflow#create-workflow-activity-history) endpoint to execute a workflow activity.
 The response returned from the [List Workflow Instances](https://developers.procore.com/reference/rest/v1/workflow#list-workflow-instances) endpoint provides information you need to perform the next activity in a specific workflow.
@@ -175,8 +173,7 @@ Executing this call returns a JSON response similar to the following:
 }
 ```
 
-## Retrieving a List of Workflow Activity Histories
-
+## Retrieve Workflow Activity Histories
 Once a workflow instance has been initiated, you can use the [List Workflow Activity Histories](https://developers.procore.com/reference/rest/v1/workflow#list-workflow-activity-histories) endpoint to retrieve a list of the activities that have been executed on the workflow.
 
 A sample GET request to the [List Workflow Activity Histories](https://developers.procore.com/reference/rest/v1/workflow#list-workflow-activity-histories) endpoint would take the following format:

--- a/tutorials/using_sync_actions.md
+++ b/tutorials/using_sync_actions.md
@@ -22,7 +22,7 @@ The attributes for each successfully created or updated resource will appear in 
 The attributes for each resource will match those returned by the Show action.
 For each resource which could not be created or updated, the attributes supplied by the caller are present in the errors list, along with an additional errors attribute which provides reasons for the failure.
 
-## Behavior
+## Sync Behavior
 The Sync action uses two different types of unique identifiers to determine whether a new resource is to be created or an existing resource is to be updated.
 The unique identifiers are supplied as the `id` and/or `origin_id` attributes.
 If neither of these identifiers are provided, a new resource is created.
@@ -45,8 +45,7 @@ The same Origin ID may not be used in more than one project within a given compa
 Origin IDs are allowed to be the same across companies.
 In other words, the same Origin ID can be used in more than one company, but cannot be used in more than one project within a single company.
 
-## Examples
-
+## Sync Examples
 **Example 1 - Caller does not pass ID or Origin ID**
 
 In the following examples we'll use Projects to illustrate using the Sync action.


### PR DESCRIPTION
AGX-7204 — "On this page" navigation rail

Adds a right-hand section rail to every docs page, and normalises the headings it exposes. The rail turned out to be a forcing function: once every H2 renders verbatim in a 202px column, headings that only made sense mid-page become dead entries. Roughly two thirds of this diff is that cleanup.

The rail — sticky column listing each page's H2 sections with scroll-spy. Single tier, H2 only, appears at three or more indexable sections. No length threshold, deliberately: measured against the corpus, every page already exceeds 1.5 viewports, so a scroll-depth gate would never fire. Excludes injected chrome and exit ramps; {: .toc-exclude} is the per-heading escape hatch. Styling benchmarked against MDN, GitHub Docs, Shopify, Microsoft Learn and Stripe — 14px, flat, 202px, sticky — with hover/active states lifted from Procore's own AnchorSection component.

Fixes a pre-existing site-wide bug. The layout sets <base target="_parent">, so every bare <a href="#..."> resolved into the parent browsing context. Because the docs are iframed on developers.procore.com, clicking any in-content anchor tore the page out of its frame and stranded the reader on a navless page. Reproduced in a harness and fixed for the ~184 existing anchors as well as the rail. This was live before this branch.

Layout — content card removed for a single white surface; a responsive ladder that spends the page frame and column gutters before the reading column gives up width; sidebar 440→400px; sidebar search field restyled.

Heading normalisation, 78 files. Exit ramps collapsed from thirteen spellings to two house headings. Heading forms aligned to Google's style guide, with Title Case deliberately retained to match Procore Support. And content promoted out of invisibility — three markup causes, same symptom:

/side-panel-view-keys 0 → 15 rail entries (14 labels were H4; 166 rows of lookup tables with no navigation)
/marketplace-policy 0 → 9 (8 clauses were H3)
/quick-start-guide 3 → 9 and /marketplace-checklist 2 → 7 (steps were collapseListTierOne)

Case changes and H3/H4 promotions preserve anchors; reworded headings with inbound links were updated alongside their linking pages. A cross-page validator confirms no anchor regressions.

Testing. Verified in an iframe harness at six widths: hideNav works, the rail appears and hides at the right breakpoint, no horizontal overflow, all anchors carry target="_self", and clicking a rail entry leaves the parent intact. Scroll-spy and sticky verified top-level on the longest page in the corpus.

Not verified: embedded scroll-spy, because the preview harness suspends requestAnimationFrame inside iframes. Testing in the real ReadMe page isn't possible pre-merge — its CSP allows frame-src 'self' https://procore.github.io/ and nothing else. That origin is allowlisted, so it becomes testable the moment this deploys. Post-deploy: check one sidebar not two, scroll behaviour, a rail click, and an in-content link.